### PR TITLE
Add block height to rest responses

### DIFF
--- a/module/x/peggy/client/rest/query.go
+++ b/module/x/peggy/client/rest/query.go
@@ -12,16 +12,14 @@ import (
 
 func currentValsetHandler(cliCtx context.CLIContext, storeName string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-
-		res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/currentValset", storeName), nil)
+		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/currentValset", storeName), nil)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusNotFound, err.Error())
 			return
 		}
-
 		var out types.Valset
 		cliCtx.Codec.MustUnmarshalJSON(res, &out)
-		rest.PostProcessResponse(w, cliCtx, res)
+		rest.PostProcessResponse(w, cliCtx.WithHeight(height), res)
 	}
 }
 
@@ -29,9 +27,8 @@ func getValsetRequestHandler(cliCtx context.CLIContext, storeName string) http.H
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		nonce := vars[nonce]
-		println("custom/%s/valsetRequest/%s ", storeName, nonce)
 
-		res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/valsetRequest/%s", storeName, nonce), nil)
+		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/valsetRequest/%s", storeName, nonce), nil)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
@@ -41,7 +38,7 @@ func getValsetRequestHandler(cliCtx context.CLIContext, storeName string) http.H
 		// looks like the sdk uses client context TODO investigate
 		var out types.Valset
 		cliCtx.Codec.MustUnmarshalJSON(res, &out)
-		rest.PostProcessResponse(w, cliCtx, res)
+		rest.PostProcessResponse(w, cliCtx.WithHeight(height), res)
 	}
 }
 


### PR DESCRIPTION
 🚧   Draft for early feedback

Resolves #2 

The fix is quite trivial but automated tests are very complex as they require a running node. 
I was only able to manually verify that `curl http://localhost:1317/peggy/current_valset` returns the proper hight now.

Todo:
`getValsetConfirmHandler` was not modified, yet because it seems not to return anything. 