### PR TITLE
WIP: Change valset storage for easier querying

### DIFF
--- a/module/x/peggy/client/rest/query.go
+++ b/module/x/peggy/client/rest/query.go
@@ -38,8 +38,6 @@ func getValsetRequestHandler(cliCtx context.CLIContext, storeName string) http.H
 			return
 		}
 
-		// why doesn't this cliCtx update it's height on it's own?
-		// looks like the sdk uses client context TODO investigate
 		var out types.Valset
 		cliCtx.Codec.MustUnmarshalJSON(res, &out)
 		rest.PostProcessResponse(w, cliCtx.WithHeight(height), res)

--- a/module/x/peggy/types/key.go
+++ b/module/x/peggy/types/key.go
@@ -24,7 +24,14 @@ var (
 	EthAddressKey    = []byte{0x1}
 	ValsetRequestKey = []byte{0x2}
 	ValsetConfirmKey = []byte{0x3}
+	ValsetIndexKey   = []byte{0x4}
 )
+
+// GetValsetIndexKey returns a fixed key, there is only one instance
+// of the valset index
+func GetValsetIndexKey() []byte {
+	return ValsetIndexKey
+}
 
 func GetEthAddressKey(validator sdk.AccAddress) []byte {
 	return append(EthAddressKey, []byte(validator)...)


### PR DESCRIPTION
This patch is an incomplete thought at the moment, I started thinking
that I would create an index of validator set requests and confirmations
in parallel to the existing storage systems simply to make things easier to
look up.

But after working with it some I've started down the track of making a single
monolithic index object that simply gets valset requests and confirmations added
into it's state.

I'm not really sure if this is a good or a bad idea as my knowlege of the inner workings
of the Cosmos store is nearly zero.

What we need is

* An endpoint to list all the validator set request block heights
* An endpoint to display all the valset confirms for a given block height

The exact backend is left to work out.

This is related to #3 