### PR TITLE
Add new REST endpoints for orchestrator process

### DIFF
--- a/module/x/peggy/client/rest/query.go
+++ b/module/x/peggy/client/rest/query.go
@@ -74,3 +74,24 @@ func getValsetConfirmHandler(cliCtx context.CLIContext, storeName string) http.H
 		rest.PostProcessResponse(w, cliCtx.WithHeight(height), res)
 	}
 }
+
+func allValsetConfirmsHandler(cliCtx context.CLIContext, storeName string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		nonce := vars[nonce]
+
+		res, height, err := cliCtx.Query(fmt.Sprintf("custom/%s/valsetConfirms/%s", storeName, nonce))
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if len(res) == 0 {
+			rest.WriteErrorResponse(w, http.StatusNotFound, "valset confirms not found")
+			return
+		}
+
+		var out []types.MsgValsetConfirm
+		cliCtx.Codec.MustUnmarshalJSON(res, &out)
+		rest.PostProcessResponse(w, cliCtx.WithHeight(height), res)
+	}
+}

--- a/module/x/peggy/client/rest/query.go
+++ b/module/x/peggy/client/rest/query.go
@@ -113,3 +113,24 @@ func lastValsetRequestsHandler(cliCtx context.CLIContext, storeName string) http
 		rest.PostProcessResponse(w, cliCtx.WithHeight(height), res)
 	}
 }
+
+func lastValsetRequestsByAddressHandler(cliCtx context.CLIContext, storeName string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		operatorAddr := vars[bech32ValidatorAddress]
+
+		res, height, err := cliCtx.Query(fmt.Sprintf("custom/%s/lastPendingValsetRequest/%s", storeName, operatorAddr))
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if len(res) == 0 {
+			rest.WriteErrorResponse(w, http.StatusNotFound, "no pending valset requests found")
+			return
+		}
+
+		var out types.Valset
+		cliCtx.Codec.MustUnmarshalJSON(res, &out)
+		rest.PostProcessResponse(w, cliCtx.WithHeight(height), res)
+	}
+}

--- a/module/x/peggy/client/rest/query.go
+++ b/module/x/peggy/client/rest/query.go
@@ -95,3 +95,21 @@ func allValsetConfirmsHandler(cliCtx context.CLIContext, storeName string) http.
 		rest.PostProcessResponse(w, cliCtx.WithHeight(height), res)
 	}
 }
+
+func lastValsetRequestsHandler(cliCtx context.CLIContext, storeName string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		res, height, err := cliCtx.Query(fmt.Sprintf("custom/%s/lastValsetRequests", storeName))
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if len(res) == 0 {
+			rest.WriteErrorResponse(w, http.StatusNotFound, "valset requests not found")
+			return
+		}
+
+		var out []types.Valset
+		cliCtx.Codec.MustUnmarshalJSON(res, &out)
+		rest.PostProcessResponse(w, cliCtx.WithHeight(height), res)
+	}
+}

--- a/module/x/peggy/client/rest/rest.go
+++ b/module/x/peggy/client/rest/rest.go
@@ -21,4 +21,5 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) 
 	r.HandleFunc(fmt.Sprintf("/%s/update_ethaddr", storeName), updateEthAddressHandler(cliCtx)).Methods("POST")
 	r.HandleFunc(fmt.Sprintf("/%s/valset_request", storeName), createValsetRequestHandler(cliCtx)).Methods("POST")
 	r.HandleFunc(fmt.Sprintf("/%s/valset_confirm", storeName), createValsetConfirmHandler(cliCtx, storeName)).Methods("POST")
+	r.HandleFunc(fmt.Sprintf("/%s/valset_confirm/{%s}", storeName, nonce), allValsetConfirmsHandler(cliCtx, storeName)).Methods("GET")
 }

--- a/module/x/peggy/client/rest/rest.go
+++ b/module/x/peggy/client/rest/rest.go
@@ -23,4 +23,5 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) 
 	r.HandleFunc(fmt.Sprintf("/%s/valset_confirm", storeName), createValsetConfirmHandler(cliCtx, storeName)).Methods("POST")
 	r.HandleFunc(fmt.Sprintf("/%s/valset_confirm/{%s}", storeName, nonce), allValsetConfirmsHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/valset_requests", storeName), lastValsetRequestsHandler(cliCtx, storeName)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/pending_valset_requests/{%s}", storeName, bech32ValidatorAddress), lastValsetRequestsByAddressHandler(cliCtx, storeName)).Methods("GET")
 }

--- a/module/x/peggy/client/rest/rest.go
+++ b/module/x/peggy/client/rest/rest.go
@@ -22,4 +22,5 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) 
 	r.HandleFunc(fmt.Sprintf("/%s/valset_request", storeName), createValsetRequestHandler(cliCtx)).Methods("POST")
 	r.HandleFunc(fmt.Sprintf("/%s/valset_confirm", storeName), createValsetConfirmHandler(cliCtx, storeName)).Methods("POST")
 	r.HandleFunc(fmt.Sprintf("/%s/valset_confirm/{%s}", storeName, nonce), allValsetConfirmsHandler(cliCtx, storeName)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/valset_requests", storeName), lastValsetRequestsHandler(cliCtx, storeName)).Methods("GET")
 }

--- a/module/x/peggy/keeper/keeper.go
+++ b/module/x/peggy/keeper/keeper.go
@@ -67,6 +67,12 @@ func (k Keeper) SetValsetConfirm(ctx sdk.Context, valsetConf types.MsgValsetConf
 	store.Set(types.GetValsetConfirmKey(valsetConf.Nonce, valsetConf.Validator), k.cdc.MustMarshalBinaryBare(valsetConf))
 }
 
+func (k Keeper) HasValsetConfirm(ctx sdk.Context, nonce int64, validatorAddr sdk.AccAddress) bool {
+	// todo: param should be sdk.ValAddress instead
+	store := ctx.KVStore(k.storeKey)
+	return store.Has(types.GetValsetConfirmKey(nonce, validatorAddr))
+}
+
 func (k Keeper) GetValsetConfirm(ctx sdk.Context, nonce int64, validator sdk.AccAddress) *types.MsgValsetConfirm {
 	store := ctx.KVStore(k.storeKey)
 	entity := store.Get(types.GetValsetConfirmKey(nonce, validator))

--- a/module/x/peggy/keeper/keeper_test.go
+++ b/module/x/peggy/keeper/keeper_test.go
@@ -1,0 +1,39 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrefixRange(t *testing.T) {
+	cases := map[string]struct {
+		src      []byte
+		expStart []byte
+		expEnd   []byte
+		expPanic bool
+	}{
+		"normal":                 {src: []byte{1, 3, 4}, expStart: []byte{1, 3, 4}, expEnd: []byte{1, 3, 5}},
+		"normal short":           {src: []byte{79}, expStart: []byte{79}, expEnd: []byte{80}},
+		"empty case":             {src: []byte{}},
+		"roll-over example 1":    {src: []byte{17, 28, 255}, expStart: []byte{17, 28, 255}, expEnd: []byte{17, 29, 0}},
+		"roll-over example 2":    {src: []byte{15, 42, 255, 255}, expStart: []byte{15, 42, 255, 255}, expEnd: []byte{15, 43, 0, 0}},
+		"pathological roll-over": {src: []byte{255, 255, 255, 255}, expStart: []byte{255, 255, 255, 255}},
+		"nil prohibited":         {expPanic: true},
+	}
+
+	for testName, tc := range cases {
+		t.Run(testName, func(t *testing.T) {
+			if tc.expPanic {
+				require.Panics(t, func() {
+					prefixRange(tc.src)
+				})
+				return
+			}
+			start, end := prefixRange(tc.src)
+			assert.Equal(t, tc.expStart, start)
+			assert.Equal(t, tc.expEnd, end)
+		})
+	}
+}

--- a/module/x/peggy/keeper/querier_test.go
+++ b/module/x/peggy/keeper/querier_test.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/althea-net/peggy/module/x/peggy/types"
@@ -49,6 +51,61 @@ func TestQueryValsetConfirm(t *testing.T) {
 	for msg, spec := range specs {
 		t.Run(msg, func(t *testing.T) {
 			got, err := queryValsetConfirm(ctx, []string{spec.srcNonce, spec.srcAddr}, k)
+			if spec.expErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if spec.expResp == nil {
+				assert.Nil(t, got)
+				return
+			}
+			assert.JSONEq(t, string(spec.expResp), string(got))
+		})
+	}
+}
+
+func TestAllValsetConfirmsByNonce(t *testing.T) {
+	var (
+		nonce int64 = 1
+	)
+	k, ctx := CreateTestEnv(t)
+
+	// seed confirmations
+	for i := 0; i < 3; i++ {
+		addr := bytes.Repeat([]byte{byte(i)}, sdk.AddrLen)
+		k.SetValsetConfirm(ctx, types.MsgValsetConfirm{
+			Nonce:     nonce,
+			Validator: addr,
+			Signature: fmt.Sprintf("signature %d", i+1),
+		})
+	}
+
+	specs := map[string]struct {
+		srcNonce string
+		expErr   bool
+		expResp  []byte
+	}{
+		"all good": {
+			srcNonce: "1",
+			expResp: []byte(`[
+{"nonce": "1", "validator": "cosmos1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnrql8a", "signature": "signature 1"},
+{"nonce": "1", "validator": "cosmos1qyqszqgpqyqszqgpqyqszqgpqyqszqgpjnp7du", "signature": "signature 2"},
+{"nonce": "1", "validator": "cosmos1qgpqyqszqgpqyqszqgpqyqszqgpqyqszrh8mx2", "signature": "signature 3"}
+]`),
+		},
+		"unknown nonce": {
+			srcNonce: "999999",
+			expResp:  nil,
+		},
+		"invalid nonce": {
+			srcNonce: "not a valid nonce",
+			expErr:   true,
+		},
+	}
+	for msg, spec := range specs {
+		t.Run(msg, func(t *testing.T) {
+			got, err := allValsetConfirmsByNonce(ctx, spec.srcNonce, k)
 			if spec.expErr {
 				require.Error(t, err)
 				return

--- a/module/x/peggy/keeper/test_common.go
+++ b/module/x/peggy/keeper/test_common.go
@@ -55,6 +55,48 @@ func MakeTestCodec() *codec.Codec {
 	return cdc
 }
 
+var _ types.StakingKeeper = &StakingKeeperMock{}
+
+type StakingKeeperMock struct {
+	BondedValidators []staking.Validator
+	ValidatorPower   map[string]int64
+}
+
+func NewStakingKeeperMock(operators ...sdk.ValAddress) *StakingKeeperMock {
+	r := &StakingKeeperMock{
+		BondedValidators: make([]staking.Validator, 0),
+		ValidatorPower:   make(map[string]int64, 0),
+	}
+	const defaultTestPower = 100
+	for _, a := range operators {
+		r.BondedValidators = append(r.BondedValidators, staking.Validator{
+			OperatorAddress: a,
+		})
+		r.ValidatorPower[a.String()] = defaultTestPower
+	}
+	return r
+}
+
+func (s *StakingKeeperMock) GetBondedValidatorsByPower(ctx sdk.Context) []staking.Validator {
+	return s.BondedValidators
+}
+
+func (s *StakingKeeperMock) GetLastValidatorPower(ctx sdk.Context, operator sdk.ValAddress) int64 {
+	v, ok := s.ValidatorPower[operator.String()]
+	if !ok {
+		panic("unknown address")
+	}
+	return v
+}
+
+func (s *StakingKeeperMock) GetLastTotalPower(ctx sdk.Context) (power sdk.Int) {
+	var total int64
+	for _, v := range s.ValidatorPower {
+		total += v
+	}
+	return sdk.NewInt(total)
+}
+
 type AlwaysPanicStakingMock struct{}
 
 func (s AlwaysPanicStakingMock) GetBondedValidatorsByPower(ctx sdk.Context) []staking.Validator {

--- a/module/x/peggy/types/codec.go
+++ b/module/x/peggy/types/codec.go
@@ -18,5 +18,4 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgValsetConfirm{}, "peggy/MsgValsetConfirm", nil)
 
 	cdc.RegisterConcrete(Valset{}, "peggy/Valset", nil)
-
 }


### PR DESCRIPTION
Resolves #3 

With this PR three new endpoints are added that can:
### Query the last `MultiSig Set` update request that was not signed for an orchestrator address
```sh
# cosmos12flmaejjvzdtz58s4m5avx30wm8uffe7ycj4l9 : cosmos address of the orchestrator
curl http://localhost:1317/peggy/pending_valset_requests/cosmos12flmaejjvzdtz58s4m5avx30wm8uffe7ycj4l9 -H "Content-Type: application/json"
```
Response: 
```json
{"height":"2790","result":{
  "type": "peggy/Valset",
  "value": {
    "Nonce": "2162",
    "Powers": [
      "1000"
    ],
    "EthAddresses": [
      "0xb462864E395d88d6bc7C5dd5F3F5eb4cc2599255"
    ]
  }
}}
```

### List most recent requests for the `MultiSig Set` update. 

```sh
curl http://localhost:1317/peggy/valset_requests -H "Content-Type: application/json"
```

* Response
Note: The result is **limited to 5 elements**
```json
{"height":"2173","result":[
  {
    "Nonce": "2162",
    "Powers": [
      "1000"
    ],
    "EthAddresses": [
      "0xb462864E395d88d6bc7C5dd5F3F5eb4cc2599255"
    ]
  },
  {
    "Nonce": "6",
    "Powers": [
      "1000"
    ],
    "EthAddresses": [
      "0xb462864E395d88d6bc7C5dd5F3F5eb4cc2599255"
    ]
  }
]}
```

## View all signed update confirmation for a nonce
```sh
# nonce=height: 101
curl http://localhost:1317/peggy/valset_confirm/101 -H "Content-Type: application/json"
```
* Response
```json
{"height":"2191","result":[
  {
    "nonce": "6",
    "validator": "cosmos12flmaejjvzdtz58s4m5avx30wm8uffe7ycj4l9",
    "signature": "ސ\ufffdR\u0000\ufffdA\ufffdSZ\ufffd?\ufffdB\ufffd\ufffd.m\ufffd\ufffd\ufffd\ufffdq\ufffd}\ufffda\t\ufffd0\ufffdRz\ufffdMe\ufffd\ufffd\ufffd\ufffd*\ufffd\u0000\u0018q\u001fs\ufffda\ufffdU\ufffd\ufffd\ufffd\ufffd\ufffdŅ\ufffd\ufffdN\ufffd\ufffd\ufffd\u0001"
  }
]}
```

Reviewer note:
* No pagination for the `MultiSig Set` update requests implemented. Instead I have set a fix **result limit** in the code. 
The use usecase of the endpoint is not completely clear to me. With oracles we could query the last observed `MultiSig Set` update so that we have confidence in the orchestrator to send the right data.
* No CLI query support, yet. I would add them in a separate PR. Just let me know that these queries make sense.


______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
