### PR TITLE
Oracle attestation handles

### DIFF
--- a/module/x/peggy/client/rest/query.go
+++ b/module/x/peggy/client/rest/query.go
@@ -134,3 +134,24 @@ func lastValsetRequestsByAddressHandler(cliCtx context.CLIContext, storeName str
 		rest.PostProcessResponse(w, cliCtx.WithHeight(height), res)
 	}
 }
+
+func lastObservedNonceHandler(cliCtx context.CLIContext, storeName string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		claimType := vars[claimType]
+
+		res, height, err := cliCtx.Query(fmt.Sprintf("custom/%s/lastObservedNonce/%s", storeName, claimType))
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if len(res) == 0 {
+			rest.WriteErrorResponse(w, http.StatusNotFound, "no observed nonce found for this type")
+			return
+		}
+
+		var out types.Nonce
+		cliCtx.Codec.MustUnmarshalJSON(res, &out)
+		rest.PostProcessResponse(w, cliCtx.WithHeight(height), res)
+	}
+}

--- a/module/x/peggy/client/rest/rest.go
+++ b/module/x/peggy/client/rest/rest.go
@@ -11,6 +11,7 @@ import (
 const (
 	nonce                  = "nonce"
 	bech32ValidatorAddress = "bech32ValidatorAddress"
+	claimType              = "claimType"
 )
 
 // RegisterRoutes - Central function to define routes that get registered by the main application
@@ -24,4 +25,5 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) 
 	r.HandleFunc(fmt.Sprintf("/%s/valset_confirm/{%s}", storeName, nonce), allValsetConfirmsHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/valset_requests", storeName), lastValsetRequestsHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/pending_valset_requests/{%s}", storeName, bech32ValidatorAddress), lastValsetRequestsByAddressHandler(cliCtx, storeName)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/last_observed_nonce/{%s}", storeName, claimType), lastObservedNonceHandler(cliCtx, storeName)).Methods("GET")
 }

--- a/module/x/peggy/handler.go
+++ b/module/x/peggy/handler.go
@@ -53,7 +53,7 @@ func handleCreateEthereumClaims(ctx sdk.Context, keeper Keeper, msg MsgCreateEth
 		var (
 			validator = sdk.ValAddress(msg.Orchestrator) // TODO: impl find validator key for orchestrator
 		)
-		if _, err := keeper.AddClaim(ctx, c.GetType(), c.GetNonce(), validator); err != nil {
+		if _, err := keeper.AddClaim(ctx, c.GetType(), c.GetNonce(), validator, c.Details()); err != nil {
 			return nil, sdkerrors.Wrap(err, "create attestation")
 		}
 	}

--- a/module/x/peggy/handler_test.go
+++ b/module/x/peggy/handler_test.go
@@ -19,9 +19,10 @@ func TestHandleCreateEthereumClaims(t *testing.T) {
 		myValAddr                         = sdk.ValAddress(myOrchestratorAddr) // revisit when proper mapping is impl in keeper
 		myNonce                           = bytes.Repeat([]byte{2}, 12)
 		anyETHAddr                        = types.NewEthereumAddress("any-address")
+		tokenETHAddr                      = types.NewEthereumAddress("any-erc20-token-addr")
 		myBlockTime                       = time.Date(2020, 9, 14, 15, 20, 10, 0, time.UTC)
 	)
-	k, ctx, _ := keeper.CreateTestEnv(t)
+	k, ctx, keepers := keeper.CreateTestEnv(t)
 	k.StakingKeeper = keeper.NewStakingKeeperMock(myValAddr)
 	h := NewHandler(k)
 
@@ -31,8 +32,12 @@ func TestHandleCreateEthereumClaims(t *testing.T) {
 		Orchestrator:          myOrchestratorAddr,
 		Claims: []EthereumClaim{
 			EthereumBridgeDepositClaim{
-				Nonce:          myNonce,
-				ERC20Token:     types.ERC20Token{},
+				Nonce: myNonce,
+				ERC20Token: types.ERC20Token{
+					Amount:               12,
+					Symbol:               "ALX",
+					TokenContractAddress: tokenETHAddr,
+				},
 				EthereumSender: anyETHAddr,
 				CosmosReceiver: myCosmosAddr,
 			},
@@ -44,26 +49,13 @@ func TestHandleCreateEthereumClaims(t *testing.T) {
 	// then
 	require.NoError(t, err)
 	// and claim persisted
-	claimFound := k.HasClaim(ctx, types.ClaimTypeEthereumBridgeDeposit, myNonce, myValAddr)
+	claimFound := k.HasClaim(ctx, types.ClaimTypeEthereumBridgeDeposit, myNonce, myValAddr, msg.Claims[0].Details())
 	assert.True(t, claimFound)
 	// and attestation persisted
 	a := k.GetAttestation(ctx, types.ClaimTypeEthereumBridgeDeposit, myNonce)
 	require.NotNil(t, a)
+	// and vouchers added to the account
+	balance := keepers.BankKeeper.GetCoins(ctx, myCosmosAddr)
+	assert.Equal(t, sdk.Coins{sdk.NewInt64Coin("peggy96dde7db38", 12)}, balance)
 
-	exp := types.Attestation{
-		ClaimType:     types.ClaimTypeEthereumBridgeDeposit,
-		Nonce:         myNonce,
-		Certainty:     types.CertaintyObserved,
-		Status:        types.ProcessStatusProcessed,
-		ProcessResult: types.ProcessResultSuccess,
-		Tally: types.AttestationTally{
-			TotalVotesPower:    sdk.NewUint(100),
-			TotalVotesCount:    1,
-			RequiredVotesPower: sdk.NewUint(66),
-			RequiredVotesCount: 0,
-		},
-		SubmitTime:          myBlockTime,
-		ConfirmationEndTime: time.Date(2020, 9, 14+1, 15, 20, 10, 0, time.UTC),
-	}
-	assert.Equal(t, exp, *a)
 }

--- a/module/x/peggy/keeper/attestation_handler.go
+++ b/module/x/peggy/keeper/attestation_handler.go
@@ -36,7 +36,7 @@ func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation) error
 			return sdkerrors.Wrap(err, "transfer vouchers")
 		}
 	case types.ClaimTypeEthereumBridgeWithdrawalBatch:
-		batchID := att.Nonce.AsUint64()
+		batchID := att.Nonce.Uint64()
 		b := a.keeper.GetOutgoingTXBatch(ctx, batchID)
 		if b == nil {
 			return types.ErrUnknown
@@ -45,21 +45,15 @@ func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation) error
 			return err
 		}
 		a.keeper.storeBatch(ctx, batchID, *b)
-		if err := a.keeper.UpdateLastObservedBatchID(ctx, batchID); err != nil {
-			return err
-		}
 		// cleanup outgoing TX pool
 		for i := range b.Elements {
 			a.keeper.removePoolEntry(ctx, b.Elements[i].ID)
 		}
 		return nil
 	case types.ClaimTypeEthereumBridgeMultiSigUpdate:
-		height := att.Nonce.AsUint64()
+		height := att.Nonce.Uint64()
 		if !a.keeper.HasValsetRequest(ctx, height) {
 			return types.ErrUnknown
-		}
-		if err := a.keeper.UpdateLastObservedMultiSigSet(ctx, height); err != nil {
-			return err
 		}
 
 		// todo: is there any cleanup for us like:

--- a/module/x/peggy/keeper/batch.go
+++ b/module/x/peggy/keeper/batch.go
@@ -135,3 +135,22 @@ func (k Keeper) GetLastObservedBatchID(ctx sdk.Context) uint64 {
 	}
 	return 0
 }
+
+func (k Keeper) UpdateLastObservedMultiSigSet(ctx sdk.Context, height uint64) error {
+	oldValue := k.GetLastObservedMultiSigSetHeight(ctx)
+	if oldValue >= height {
+		return sdkerrors.Wrapf(types.ErrInvalid, "new value must be greater %d", oldValue)
+	}
+	store := ctx.KVStore(k.storeKey)
+	store.Set(types.LastObservedMultiSigSetUpdateKey, sdk.Uint64ToBigEndian(height))
+	return nil
+}
+
+func (k Keeper) GetLastObservedMultiSigSetHeight(ctx sdk.Context) uint64 {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(types.LastObservedMultiSigSetUpdateKey)
+	if bz != nil {
+		return binary.BigEndian.Uint64(bz)
+	}
+	return 0
+}

--- a/module/x/peggy/keeper/batch.go
+++ b/module/x/peggy/keeper/batch.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"encoding/binary"
 	"strconv"
 
 	"github.com/althea-net/peggy/module/x/peggy/types"
@@ -115,42 +114,4 @@ func (k Keeper) CancelOutgoingTXBatch(ctx sdk.Context, batchID uint64) error {
 	)
 	ctx.EventManager().EmitEvent(batchEvent)
 	return nil
-}
-
-func (k Keeper) UpdateLastObservedBatchID(ctx sdk.Context, batchID uint64) error {
-	oldValue := k.GetLastObservedBatchID(ctx)
-	if oldValue >= batchID {
-		return sdkerrors.Wrapf(types.ErrInvalid, "new value must be greater %d", oldValue)
-	}
-	store := ctx.KVStore(k.storeKey)
-	store.Set(types.LastObservedBatchKey, sdk.Uint64ToBigEndian(batchID))
-	return nil
-}
-
-func (k Keeper) GetLastObservedBatchID(ctx sdk.Context) uint64 {
-	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.LastObservedBatchKey)
-	if bz != nil {
-		return binary.BigEndian.Uint64(bz)
-	}
-	return 0
-}
-
-func (k Keeper) UpdateLastObservedMultiSigSet(ctx sdk.Context, height uint64) error {
-	oldValue := k.GetLastObservedMultiSigSetHeight(ctx)
-	if oldValue >= height {
-		return sdkerrors.Wrapf(types.ErrInvalid, "new value must be greater %d", oldValue)
-	}
-	store := ctx.KVStore(k.storeKey)
-	store.Set(types.LastObservedMultiSigSetUpdateKey, sdk.Uint64ToBigEndian(height))
-	return nil
-}
-
-func (k Keeper) GetLastObservedMultiSigSetHeight(ctx sdk.Context) uint64 {
-	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.LastObservedMultiSigSetUpdateKey)
-	if bz != nil {
-		return binary.BigEndian.Uint64(bz)
-	}
-	return 0
 }

--- a/module/x/peggy/keeper/batch_test.go
+++ b/module/x/peggy/keeper/batch_test.go
@@ -14,12 +14,12 @@ import (
 func TestBatches(t *testing.T) {
 	k, ctx, keepers := CreateTestEnv(t)
 	var (
-		mySender             = bytes.Repeat([]byte{1}, sdk.AddrLen)
-		myReceiver           = "eth receiver"
-		myBridgeContractAddr = "my eth bridge contract address"
-		myETHToken           = "myETHToken"
-		voucherDenom         = types.NewVoucherDenom(myBridgeContractAddr, myETHToken)
-		now                  = time.Now().UTC()
+		mySender            = bytes.Repeat([]byte{1}, sdk.AddrLen)
+		myReceiver          = "eth receiver"
+		myTokenContractAddr = types.NewEthereumAddress("my eth oken address")
+		myETHToken          = "myETHToken"
+		voucherDenom        = types.NewVoucherDenom(myTokenContractAddr, myETHToken)
+		now                 = time.Now().UTC()
 	)
 	// mint some voucher first
 	allVouchers := sdk.Coins{sdk.NewInt64Coin(string(voucherDenom), 99999)}
@@ -32,7 +32,7 @@ func TestBatches(t *testing.T) {
 	require.NoError(t, err)
 
 	// store counterpart
-	k.StoreCounterpartDenominator(ctx, myBridgeContractAddr, myETHToken)
+	k.StoreCounterpartDenominator(ctx, myTokenContractAddr, myETHToken)
 
 	// add some TX to the pool
 	for i, v := range []int64{2, 3, 2, 1} {
@@ -68,12 +68,12 @@ func TestBatches(t *testing.T) {
 				Amount:      types.NewTransferCoin(myETHToken, 100),
 			},
 		},
-		CreatedAt:             now,
-		TotalFee:              types.NewTransferCoin(myETHToken, 5),
-		CosmosDenom:           voucherDenom,
-		BridgedTokenID:        myETHToken,
-		BridgeContractAddress: myBridgeContractAddr,
-		BatchStatus:           types.BatchStatusPending,
+		CreatedAt:                   now,
+		TotalFee:                    types.NewTransferCoin(myETHToken, 5),
+		CosmosDenom:                 voucherDenom,
+		BridgedTokenSymbol:          myETHToken,
+		BridgedTokenContractAddress: myTokenContractAddr,
+		BatchStatus:                 types.BatchStatusPending,
 	}
 	assert.Equal(t, expBatch, *gotBatch)
 

--- a/module/x/peggy/keeper/keeper.go
+++ b/module/x/peggy/keeper/keeper.go
@@ -17,7 +17,7 @@ type Keeper struct {
 	storeKey sdk.StoreKey // Unexposed key to access store from sdk.Context
 
 	cdc          *codec.Codec // The wire codec for binary encoding/decoding.
-	supplyKeeper SupplyKeeper
+	supplyKeeper types.SupplyKeeper
 
 	AttestationHandler interface {
 		Handle(sdk.Context, types.Attestation) error
@@ -26,14 +26,17 @@ type Keeper struct {
 
 // NewKeeper
 func NewKeeper(cdc *codec.Codec, storeKey sdk.StoreKey, stakingKeeper types.StakingKeeper,
-	supplyKeeper SupplyKeeper) Keeper {
+	supplyKeeper types.SupplyKeeper) Keeper {
 	k := Keeper{
 		cdc:           cdc,
 		storeKey:      storeKey,
 		StakingKeeper: stakingKeeper,
 		supplyKeeper:  supplyKeeper,
 	}
-	k.AttestationHandler = AttestationHandler{keeper: k}
+	k.AttestationHandler = AttestationHandler{
+		keeper:       k,
+		supplyKeeper: supplyKeeper,
+	}
 	return k
 }
 

--- a/module/x/peggy/keeper/keeper.go
+++ b/module/x/peggy/keeper/keeper.go
@@ -48,6 +48,11 @@ func (k Keeper) SetValsetRequest(ctx sdk.Context) {
 	store.Set(types.GetValsetRequestKey(nonce), k.cdc.MustMarshalBinaryBare(valset))
 }
 
+func (k Keeper) HasValsetRequest(ctx sdk.Context, nonce uint64) bool {
+	store := ctx.KVStore(k.storeKey)
+	return store.Has(types.GetValsetRequestKey(int64(nonce))) // todo: revisit type where nonce is used as int64
+}
+
 func (k Keeper) GetValsetRequest(ctx sdk.Context, nonce int64) *types.Valset {
 	store := ctx.KVStore(k.storeKey)
 

--- a/module/x/peggy/keeper/oracle.go
+++ b/module/x/peggy/keeper/oracle.go
@@ -52,7 +52,7 @@ func (k Keeper) AddClaim(ctx sdk.Context, claimType types.ClaimType, nonce types
 func (k Keeper) processAttestation(ctx sdk.Context, att *types.Attestation) {
 	xCtx, commit := ctx.CacheContext()
 	if err := k.AttestationHandler.Handle(xCtx, *att); err != nil { // execute with a transient storage
-		// log
+		ctx.Logger().Error("attestation failed", "cause", err.Error())
 		att.ProcessResult = types.ProcessResultFailure
 	} else {
 		att.ProcessResult = types.ProcessResultSuccess

--- a/module/x/peggy/keeper/oracle.go
+++ b/module/x/peggy/keeper/oracle.go
@@ -15,13 +15,13 @@ import (
 //  - `observed` attestations are processed for state transition
 //  - the process result is stored with the attestion
 //  - an `observation` event is emitted
-func (k Keeper) AddClaim(ctx sdk.Context, claimType types.ClaimType, nonce types.Nonce, validator sdk.ValAddress) (*types.Attestation, error) {
-	if err := k.storeClaim(ctx, claimType, nonce, validator); err != nil {
+func (k Keeper) AddClaim(ctx sdk.Context, claimType types.ClaimType, nonce types.Nonce, validator sdk.ValAddress, details types.AttestationDetails) (*types.Attestation, error) {
+	if err := k.storeClaim(ctx, claimType, nonce, validator, details); err != nil {
 		return nil, sdkerrors.Wrap(err, "claim")
 	}
 
 	validatorPower := k.StakingKeeper.GetLastValidatorPower(ctx, validator)
-	att, err := k.tryAttestation(ctx, claimType, nonce, uint64(validatorPower))
+	att, err := k.tryAttestation(ctx, claimType, nonce, details, uint64(validatorPower))
 	if err != nil {
 		return nil, err
 	}
@@ -62,9 +62,9 @@ func (k Keeper) processAttestation(ctx sdk.Context, att *types.Attestation) {
 }
 
 // storeClaim persists a claim. Fails when a claim of given type and nonce was was submitted by the validator before
-func (k Keeper) storeClaim(ctx sdk.Context, claimType types.ClaimType, nonce types.Nonce, validator sdk.ValAddress) error {
+func (k Keeper) storeClaim(ctx sdk.Context, claimType types.ClaimType, nonce types.Nonce, validator sdk.ValAddress, details types.AttestationDetails) error {
 	store := ctx.KVStore(k.storeKey)
-	cKey := types.GetClaimKey(claimType, nonce, validator)
+	cKey := types.GetClaimKey(claimType, nonce, validator, details)
 	if store.Has(cKey) {
 		return types.ErrDuplicate
 	}
@@ -79,7 +79,7 @@ var (
 
 // tryAttestation loads an existing attestation for the given claim type and nonce and adds a vote.
 // When none exists yet, a new attestation is instantiated (but not persisted here)
-func (k Keeper) tryAttestation(ctx sdk.Context, claimType types.ClaimType, nonce types.Nonce, power uint64) (*types.Attestation, error) {
+func (k Keeper) tryAttestation(ctx sdk.Context, claimType types.ClaimType, nonce types.Nonce, details types.AttestationDetails, power uint64) (*types.Attestation, error) {
 	now := ctx.BlockTime()
 	att := k.GetAttestation(ctx, claimType, nonce)
 	if att == nil {
@@ -91,6 +91,7 @@ func (k Keeper) tryAttestation(ctx sdk.Context, claimType types.ClaimType, nonce
 			Certainty:     types.CertaintyRequested,
 			Status:        types.ProcessStatusInit,
 			ProcessResult: types.ProcessResultUnknown,
+			Details:       details,
 			Tally: types.AttestationTally{
 				TotalVotesPower:    zero,
 				RequiredVotesPower: types.AttestationVotesPowerThreshold.MulUint64(power.Uint64()).Quo(hundred),
@@ -125,7 +126,7 @@ func (k Keeper) GetAttestation(ctx sdk.Context, claimType types.ClaimType, nonce
 	return &att
 }
 
-func (k Keeper) HasClaim(ctx sdk.Context, claimType types.ClaimType, nonce types.Nonce, validator sdk.ValAddress) bool {
+func (k Keeper) HasClaim(ctx sdk.Context, claimType types.ClaimType, nonce types.Nonce, validator sdk.ValAddress, details types.AttestationDetails) bool {
 	store := ctx.KVStore(k.storeKey)
-	return store.Has(types.GetClaimKey(claimType, nonce, validator))
+	return store.Has(types.GetClaimKey(claimType, nonce, validator, details))
 }

--- a/module/x/peggy/keeper/oracle_test.go
+++ b/module/x/peggy/keeper/oracle_test.go
@@ -1,0 +1,65 @@
+package keeper
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/althea-net/peggy/module/x/peggy/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestName(t *testing.T) {
+	var (
+		myOrchestratorAddr sdk.AccAddress = make([]byte, sdk.AddrLen)
+		myCosmosAddr       sdk.AccAddress = bytes.Repeat([]byte{1}, 12)
+		myValAddr                         = sdk.ValAddress(myOrchestratorAddr) // revisit when proper mapping is impl in keeper
+		myNonce                           = bytes.Repeat([]byte{2}, 12)
+		anyETHAddr                        = types.NewEthereumAddress("any-address")
+		tokenETHAddr                      = types.NewEthereumAddress("any-erc20-token-addr")
+		myBlockTime                       = time.Date(2020, 9, 14, 15, 20, 10, 0, time.UTC)
+	)
+
+	k, ctx, _ := CreateTestEnv(t)
+	k.StakingKeeper = NewStakingKeeperMock(myValAddr)
+
+	// when
+	ctx = ctx.WithBlockTime(myBlockTime)
+	depositDetails := types.BridgeDeposit{
+		ERC20Token: types.ERC20Token{
+			Amount:               12,
+			Symbol:               "ALX",
+			TokenContractAddress: tokenETHAddr,
+		},
+		EthereumSender: anyETHAddr,
+		CosmosReceiver: myCosmosAddr,
+	}
+	gotAttestation, err := k.AddClaim(ctx, types.ClaimTypeEthereumBridgeDeposit, myNonce, myValAddr, depositDetails)
+	// then
+	require.NoError(t, err)
+
+	// and claim persisted
+	claimFound := k.HasClaim(ctx, types.ClaimTypeEthereumBridgeDeposit, myNonce, myValAddr, depositDetails)
+	assert.True(t, claimFound)
+
+	// and expected state
+	exp := types.Attestation{
+		ClaimType:     types.ClaimTypeEthereumBridgeDeposit,
+		Nonce:         myNonce,
+		Certainty:     types.CertaintyObserved,
+		Status:        types.ProcessStatusProcessed,
+		ProcessResult: types.ProcessResultSuccess,
+		Tally: types.AttestationTally{
+			TotalVotesPower:    sdk.NewUint(100),
+			TotalVotesCount:    1,
+			RequiredVotesPower: sdk.NewUint(66),
+			RequiredVotesCount: 0,
+		},
+		SubmitTime:          myBlockTime,
+		ConfirmationEndTime: time.Date(2020, 9, 14+1, 15, 20, 10, 0, time.UTC),
+		Details:             depositDetails,
+	}
+	assert.Equal(t, exp, *gotAttestation)
+}

--- a/module/x/peggy/keeper/oracle_test.go
+++ b/module/x/peggy/keeper/oracle_test.go
@@ -107,7 +107,8 @@ func TestObserveWithdrawBatch(t *testing.T) {
 	}
 	assert.Equal(t, exp, *gotAttestation)
 	// and last observed status updated
-	assert.Equal(t, myBatchID, k.GetLastObservedBatchID(ctx))
+	gotNonce := k.GetLastObservedNonce(ctx, types.ClaimTypeEthereumBridgeWithdrawalBatch)
+	assert.Equal(t, myNonce, gotNonce)
 }
 
 func TestObserveBridgeMultiSigUpdate(t *testing.T) {
@@ -152,5 +153,6 @@ func TestObserveBridgeMultiSigUpdate(t *testing.T) {
 	}
 	assert.Equal(t, exp, *gotAttestation)
 	// and last observed status updated
-	assert.Equal(t, myBlockHeight, k.GetLastObservedMultiSigSetHeight(ctx))
+	gotNonce := k.GetLastObservedNonce(ctx, types.ClaimTypeEthereumBridgeMultiSigUpdate)
+	assert.Equal(t, myNonce, gotNonce)
 }

--- a/module/x/peggy/keeper/pool.go
+++ b/module/x/peggy/keeper/pool.go
@@ -8,22 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
 )
-
-// SupplyKeeper defines the expected supply keeper
-type SupplyKeeper interface {
-	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
-	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
-	MintCoins(ctx sdk.Context, name string, amt sdk.Coins) error
-	BurnCoins(ctx sdk.Context, name string, amt sdk.Coins) error
-	//SetModuleAccount(sdk.Context, supply.ModuleAccountI)
-}
-
-// AccountKeeper defines the expected account keeper
-type AccountKeeper interface {
-	GetAccount(sdk.Context, sdk.AccAddress) authexported.Account
-}
 
 // AddToOutgoingPool
 // - checks a counterpart denomintor exists for the given voucher type

--- a/module/x/peggy/keeper/pool.go
+++ b/module/x/peggy/keeper/pool.go
@@ -40,7 +40,7 @@ func (k Keeper) AddToOutgoingPool(ctx sdk.Context, sender sdk.AccAddress, counte
 	// persist TX in pool
 	nextID := k.autoIncrementID(ctx, types.KeyLastTXPoolID)
 	outgoing := types.OutgoingTx{
-		//BridgeContractAddress: , // TODO: do we need to store this?
+		//TokenContractAddress: , // TODO: do we need to store this?
 		Sender:      sender,
 		DestAddress: counterpartReceiver,
 		Amount:      amount,
@@ -141,6 +141,11 @@ func (k Keeper) getPoolEntry(ctx sdk.Context, id uint64) (*types.OutgoingTx, err
 	return &r, nil
 }
 
+func (k Keeper) removePoolEntry(ctx sdk.Context, id uint64) {
+	store := ctx.KVStore(k.storeKey)
+	store.Delete(types.GetOutgoingTxPoolKey(id))
+}
+
 // GetCounterpartDenominator returns the token details on the counterpart chain for given voucher type
 func (k Keeper) GetCounterpartDenominator(ctx sdk.Context, voucherDenom types.VoucherDenom) *types.BridgedDenominator {
 	store := ctx.KVStore(k.storeKey)
@@ -154,12 +159,12 @@ func (k Keeper) GetCounterpartDenominator(ctx sdk.Context, voucherDenom types.Vo
 }
 
 // StoreCounterpartDenominator persists the bridged token details. Overwrites an existing entry without error
-func (k Keeper) StoreCounterpartDenominator(ctx sdk.Context, bridgeContractAddr, tokenID string) {
+func (k Keeper) StoreCounterpartDenominator(ctx sdk.Context, tokenContractAddress types.EthereumAddress, symbol string) {
 	store := ctx.KVStore(k.storeKey)
-	voucherDenominator := types.NewVoucherDenom(bridgeContractAddr, tokenID)
+	voucherDenominator := types.NewVoucherDenom(tokenContractAddress, symbol)
 	bridgedDenominator := types.BridgedDenominator{
-		BridgeContractAddress: bridgeContractAddr,
-		TokenID:               tokenID,
+		TokenContractAddress: tokenContractAddress,
+		Symbol:               symbol,
 	}
 	store.Set(types.GetDenominatorKey(voucherDenominator.Unprefixed()), k.cdc.MustMarshalBinaryBare(bridgedDenominator))
 }

--- a/module/x/peggy/keeper/pool_test.go
+++ b/module/x/peggy/keeper/pool_test.go
@@ -13,11 +13,11 @@ import (
 func TestAddToOutgoingPool(t *testing.T) {
 	k, ctx, keepers := CreateTestEnv(t)
 	var (
-		mySender             = bytes.Repeat([]byte{1}, sdk.AddrLen)
-		myReceiver           = "eth receiver"
-		myBridgeContractAddr = "my eth bridge contract address"
-		myETHToken           = "myETHToken"
-		voucherDenom         = types.NewVoucherDenom(myBridgeContractAddr, myETHToken)
+		mySender            = bytes.Repeat([]byte{1}, sdk.AddrLen)
+		myReceiver          = "eth receiver"
+		myETHToken          = "myETHToken"
+		myTokenContractAddr = types.NewEthereumAddress("my eth oken address")
+		voucherDenom        = types.NewVoucherDenom(myTokenContractAddr, myETHToken)
 	)
 	// mint some voucher first
 	allVouchers := sdk.Coins{sdk.NewInt64Coin(string(voucherDenom), 99999)}
@@ -30,7 +30,7 @@ func TestAddToOutgoingPool(t *testing.T) {
 	require.NoError(t, err)
 
 	// store counterpart
-	k.StoreCounterpartDenominator(ctx, myBridgeContractAddr, myETHToken)
+	k.StoreCounterpartDenominator(ctx, myTokenContractAddr, myETHToken)
 
 	// when
 	for i, v := range []int64{2, 3, 2, 1} {

--- a/module/x/peggy/keeper/querier.go
+++ b/module/x/peggy/keeper/querier.go
@@ -17,6 +17,7 @@ const (
 	QueryValsetConfirmsByNonce          = "valsetConfirms"
 	QueryLastValsetRequests             = "lastValsetRequests"
 	QueryLastPendingValsetRequestByAddr = "lastPendingValsetRequest"
+	QueryLastObservedNonce              = "lastObservedNonce"
 )
 
 // NewQuerier is the module level router for state queries
@@ -35,6 +36,8 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 			return lastValsetRequests(ctx, keeper)
 		case QueryLastPendingValsetRequestByAddr:
 			return lastPendingValsetRequest(ctx, path[1], keeper)
+		case QueryLastObservedNonce:
+			return lastObservedNonce(ctx, path[1], keeper)
 		default:
 			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "unknown nameservice query endpoint")
 		}
@@ -160,6 +163,16 @@ func lastPendingValsetRequest(ctx sdk.Context, operatorAddr string, keeper Keepe
 		return nil, nil
 	}
 	res, err := codec.MarshalJSONIndent(keeper.cdc, pendingValsetReq)
+	if err != nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+	}
+	return res, nil
+}
+
+func lastObservedNonce(ctx sdk.Context, claimType string, keeper Keeper) ([]byte, error) {
+	// todo: verify claim type exists as defined type
+	nonce := keeper.GetLastObservedNonce(ctx, types.ClaimType(claimType))
+	res, err := codec.MarshalJSONIndent(keeper.cdc, nonce)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}

--- a/module/x/peggy/types/codec.go
+++ b/module/x/peggy/types/codec.go
@@ -30,4 +30,6 @@ func RegisterCodec(cdc *codec.Codec) {
 
 	cdc.RegisterConcrete(BridgedDenominator{}, "peggy/BridgedDenominator", nil)
 	cdc.RegisterConcrete(IDSet{}, "peggy/IDSet", nil)
+	cdc.RegisterInterface((*AttestationDetails)(nil), nil)
+	cdc.RegisterConcrete(BridgeDeposit{}, "peggy/BridgeDeposit", nil)
 }

--- a/module/x/peggy/types/ethereum.go
+++ b/module/x/peggy/types/ethereum.go
@@ -46,5 +46,5 @@ func (e ERC20Token) String() string {
 
 // AsVoucherCoin converts the data into a cosmos coin with peggy voucher denom.
 func (e ERC20Token) AsVoucherCoin() sdk.Coin {
-	return sdk.NewInt64Coin(NewVoucherDenom(e.TokenContractAddress.String(), e.Symbol).String(), e.Amount)
+	return sdk.NewInt64Coin(NewVoucherDenom(e.TokenContractAddress, e.Symbol).String(), e.Amount)
 }

--- a/module/x/peggy/types/ethereum.go
+++ b/module/x/peggy/types/ethereum.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	gethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
@@ -36,4 +37,14 @@ type ERC20Token struct {
 	Amount               int64           `json:"amount" yaml:"amount"`
 	Symbol               string          `json:"symbol" yaml:"symbol"`
 	TokenContractAddress EthereumAddress `json:"token_contract_address" yaml:"token_contract_address"`
+}
+
+// String converts Token representation into a human readable form containing all data.
+func (e ERC20Token) String() string {
+	return fmt.Sprintf("%d %s (%s)", e.Amount, e.Symbol, e.TokenContractAddress.String())
+}
+
+// AsVoucherCoin converts the data into a cosmos coin with peggy voucher denom.
+func (e ERC20Token) AsVoucherCoin() sdk.Coin {
+	return sdk.NewInt64Coin(NewVoucherDenom(e.TokenContractAddress.String(), e.Symbol).String(), e.Amount)
 }

--- a/module/x/peggy/types/expected_keepers.go
+++ b/module/x/peggy/types/expected_keepers.go
@@ -10,3 +10,11 @@ type StakingKeeper interface {
 	GetLastValidatorPower(ctx sdk.Context, operator sdk.ValAddress) int64
 	GetLastTotalPower(ctx sdk.Context) (power sdk.Int)
 }
+
+// SupplyKeeper defines the expected supply keeper
+type SupplyKeeper interface {
+	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+	MintCoins(ctx sdk.Context, name string, amt sdk.Coins) error
+	BurnCoins(ctx sdk.Context, name string, amt sdk.Coins) error
+}

--- a/module/x/peggy/types/key.go
+++ b/module/x/peggy/types/key.go
@@ -21,16 +21,17 @@ const (
 )
 
 var (
-	EthAddressKey               = []byte{0x1}
-	ValsetRequestKey            = []byte{0x2}
-	ValsetConfirmKey            = []byte{0x3}
-	OracleClaimKey              = []byte{0x4}
-	OracleAttestationKey        = []byte{0x5}
-	OutgoingTXPoolKey           = []byte{0x6}
-	SequenceKeyPrefix           = []byte{0x7}
-	DenomiatorPrefix            = []byte{0x8}
-	SecondIndexOutgoingTXFeeKey = []byte{0x9}
-	LastObservedBatchKey        = []byte{0xa}
+	EthAddressKey                    = []byte{0x1}
+	ValsetRequestKey                 = []byte{0x2}
+	ValsetConfirmKey                 = []byte{0x3}
+	OracleClaimKey                   = []byte{0x4}
+	OracleAttestationKey             = []byte{0x5}
+	OutgoingTXPoolKey                = []byte{0x6}
+	SequenceKeyPrefix                = []byte{0x7}
+	DenomiatorPrefix                 = []byte{0x8}
+	SecondIndexOutgoingTXFeeKey      = []byte{0x9}
+	LastObservedBatchKey             = []byte{0xa}
+	LastObservedMultiSigSetUpdateKey = []byte{0xb}
 
 	// sequence keys
 	KeyLastTXPoolID        = append(SequenceKeyPrefix, []byte("lastTxPoolId")...)

--- a/module/x/peggy/types/key.go
+++ b/module/x/peggy/types/key.go
@@ -54,13 +54,19 @@ func GetValsetConfirmKey(nonce int64, validator sdk.AccAddress) []byte {
 	return append(ValsetConfirmKey, append(nonceBytes, []byte(validator)...)...)
 }
 
-func GetClaimKey(claimType ClaimType, nonce Nonce, validator sdk.ValAddress) []byte {
+func GetClaimKey(claimType ClaimType, nonce Nonce, validator sdk.ValAddress, details AttestationDetails) []byte {
+	var detailsHash []byte
+	if details != nil {
+		detailsHash = details.Hash()
+	}
 	claimTypeLen := len(claimType)
-	key := make([]byte, len(OracleClaimKey)+claimTypeLen+sdk.AddrLen+len(nonce))
+
+	key := make([]byte, len(OracleClaimKey)+claimTypeLen+sdk.AddrLen+len(nonce)+len(detailsHash))
 	copy(key[0:], OracleClaimKey)
 	copy(key[len(OracleClaimKey):], claimType.Bytes())
 	copy(key[len(OracleClaimKey)+claimTypeLen:], validator)
 	copy(key[len(OracleClaimKey)+claimTypeLen+sdk.AddrLen:], nonce)
+	copy(key[len(OracleClaimKey)+claimTypeLen+sdk.AddrLen+len(nonce):], detailsHash)
 	return key
 }
 

--- a/module/x/peggy/types/key.go
+++ b/module/x/peggy/types/key.go
@@ -30,6 +30,7 @@ var (
 	SequenceKeyPrefix           = []byte{0x7}
 	DenomiatorPrefix            = []byte{0x8}
 	SecondIndexOutgoingTXFeeKey = []byte{0x9}
+	LastObservedBatchKey        = []byte{0xa}
 
 	// sequence keys
 	KeyLastTXPoolID        = append(SequenceKeyPrefix, []byte("lastTxPoolId")...)

--- a/module/x/peggy/types/key.go
+++ b/module/x/peggy/types/key.go
@@ -21,17 +21,15 @@ const (
 )
 
 var (
-	EthAddressKey                    = []byte{0x1}
-	ValsetRequestKey                 = []byte{0x2}
-	ValsetConfirmKey                 = []byte{0x3}
-	OracleClaimKey                   = []byte{0x4}
-	OracleAttestationKey             = []byte{0x5}
-	OutgoingTXPoolKey                = []byte{0x6}
-	SequenceKeyPrefix                = []byte{0x7}
-	DenomiatorPrefix                 = []byte{0x8}
-	SecondIndexOutgoingTXFeeKey      = []byte{0x9}
-	LastObservedBatchKey             = []byte{0xa}
-	LastObservedMultiSigSetUpdateKey = []byte{0xb}
+	EthAddressKey               = []byte{0x1}
+	ValsetRequestKey            = []byte{0x2}
+	ValsetConfirmKey            = []byte{0x3}
+	OracleClaimKey              = []byte{0x4}
+	OracleAttestationKey        = []byte{0x5}
+	OutgoingTXPoolKey           = []byte{0x6}
+	SequenceKeyPrefix           = []byte{0x7}
+	DenomiatorPrefix            = []byte{0x8}
+	SecondIndexOutgoingTXFeeKey = []byte{0x9}
 
 	// sequence keys
 	KeyLastTXPoolID        = append(SequenceKeyPrefix, []byte("lastTxPoolId")...)

--- a/module/x/peggy/types/msgs.go
+++ b/module/x/peggy/types/msgs.go
@@ -408,15 +408,6 @@ func (msg MsgEthDeposit) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.Validator}
 }
 
-// ClaimType is the cosmos type of an event from the counterpart chain that can be handled
-type ClaimType string
-
-const (
-	ClaimTypeEthereumBridgeDeposit         ClaimType = "BridgeDeposit"
-	ClaimTypeEthereumBridgeWithdrawalBatch ClaimType = "BridgeWithdrawalBatch"
-	ClaimTypeEthereumBridgeMultiSigUpdate  ClaimType = "BridgeMultiSigUpdate"
-)
-
 func (c ClaimType) Bytes() []byte {
 	return []byte(c)
 }
@@ -425,6 +416,7 @@ type EthereumClaim interface {
 	GetNonce() Nonce
 	GetType() ClaimType
 	ValidateBasic() error
+	Details() AttestationDetails
 }
 
 var (
@@ -454,6 +446,14 @@ func (e EthereumBridgeDepositClaim) ValidateBasic() error {
 	return nil
 }
 
+func (e EthereumBridgeDepositClaim) Details() AttestationDetails {
+	return BridgeDeposit{
+		ERC20Token:     e.ERC20Token,
+		EthereumSender: e.EthereumSender,
+		CosmosReceiver: e.CosmosReceiver,
+	}
+}
+
 // EthereumBridgeWithdrawalBatchClaim claims that a batch of withdrawal operations on the bridge contract was executed.
 type EthereumBridgeWithdrawalBatchClaim struct {
 	Nonce []byte `json:"nonce" yaml:"nonce"`
@@ -472,6 +472,10 @@ func (e EthereumBridgeWithdrawalBatchClaim) ValidateBasic() error {
 	return nil
 }
 
+func (e EthereumBridgeWithdrawalBatchClaim) Details() AttestationDetails {
+	return nil
+}
+
 // EthereumBridgeMultiSigUpdateClaim claims that the multisig set was updated on the bridge contract.
 type EthereumBridgeMultiSigUpdateClaim struct {
 	Nonce []byte `json:"nonce" yaml:"nonce"`
@@ -487,6 +491,10 @@ func (e EthereumBridgeMultiSigUpdateClaim) GetNonce() Nonce {
 
 func (e EthereumBridgeMultiSigUpdateClaim) ValidateBasic() error {
 	// todo: implement me
+	return nil
+}
+
+func (e EthereumBridgeMultiSigUpdateClaim) Details() AttestationDetails {
 	return nil
 }
 

--- a/module/x/peggy/types/oracle.go
+++ b/module/x/peggy/types/oracle.go
@@ -15,12 +15,16 @@ type Nonce []byte
 func NonceFromUint64(s uint64) Nonce {
 	return sdk.Uint64ToBigEndian(s)
 }
-func (n Nonce) AsUint64() uint64 {
+func (n Nonce) Uint64() uint64 {
 	return binary.BigEndian.Uint64(n)
 }
 
 func (n Nonce) String() string {
 	return string(n)
+}
+
+func (n Nonce) Bytes() []byte {
+	return n
 }
 
 type AttestationCertainty uint8

--- a/module/x/peggy/types/oracle.go
+++ b/module/x/peggy/types/oracle.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/binary"
 	"fmt"
 	"time"
 
@@ -13,6 +14,9 @@ type Nonce []byte
 
 func NonceFromUint64(s uint64) Nonce {
 	return sdk.Uint64ToBigEndian(s)
+}
+func (n Nonce) AsUint64() uint64 {
+	return binary.BigEndian.Uint64(n)
 }
 
 func (n Nonce) String() string {

--- a/module/x/peggy/types/oracle.go
+++ b/module/x/peggy/types/oracle.go
@@ -1,10 +1,12 @@
 package types
 
 import (
+	"fmt"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/tendermint/tendermint/crypto/tmhash"
 )
 
 type Nonce []byte
@@ -42,6 +44,15 @@ const (
 	ProcessResultFailure AttestationProcessResult = 2
 )
 
+// ClaimType is the cosmos type of an event from the counterpart chain that can be handled
+type ClaimType string
+
+const (
+	ClaimTypeEthereumBridgeDeposit         ClaimType = "BridgeDeposit"
+	ClaimTypeEthereumBridgeWithdrawalBatch ClaimType = "BridgeWithdrawalBatch"
+	ClaimTypeEthereumBridgeMultiSigUpdate  ClaimType = "BridgeMultiSigUpdate"
+)
+
 // Attestation is an aggregate of `claims` that eventually becomes `observed` by all orchestrators
 type Attestation struct {
 	ClaimType           ClaimType
@@ -53,6 +64,7 @@ type Attestation struct {
 	SubmitTime          time.Time
 	ConfirmationEndTime time.Time // votes collected <= end time. should be < unbonding period
 	// ExpiryTime time.Time // todo: do we want to keep Attestations forever persisted or can we delete them?
+	Details AttestationDetails
 }
 
 type AttestationTally struct {
@@ -90,4 +102,18 @@ func (a *Attestation) AddVote(now time.Time, power uint64) error {
 // ID is the unique identifiert used in DB
 func (a *Attestation) ID() []byte {
 	return GetAttestationKey(a.ClaimType, a.Nonce)
+}
+
+type AttestationDetails interface {
+	Hash() []byte
+}
+type BridgeDeposit struct {
+	ERC20Token     ERC20Token
+	EthereumSender EthereumAddress `json:"ethereum_sender" yaml:"ethereum_sender"`
+	CosmosReceiver sdk.AccAddress  `json:"cosmos_receiver" yaml:"cosmos_receiver"`
+}
+
+func (b BridgeDeposit) Hash() []byte {
+	path := fmt.Sprintf("%s/%s/%s/", b.EthereumSender.String(), b.ERC20Token.String(), b.CosmosReceiver.String())
+	return tmhash.Sum([]byte(path))
 }

--- a/module/x/peggy/types/pool.go
+++ b/module/x/peggy/types/pool.go
@@ -16,14 +16,14 @@ type OutgoingTx struct {
 	DestAddress string         `json:"dest_address"`
 	Amount      sdk.Coin       `json:"send"`
 	BridgeFee   sdk.Coin       `json:"bridge_fee"`
-	//BridgeContractAddress string         `json:"bridge_contract_address"` // todo: do we need this?
+	//TokenContractAddress string         `json:"bridge_contract_address"` // todo: do we need this?
 }
 
 // BridgedDenominator contains bridged token details
 type BridgedDenominator struct {
 	//ChainID         string
-	BridgeContractAddress string
-	TokenID               string
+	TokenContractAddress EthereumAddress
+	Symbol               string
 }
 
 const (
@@ -51,8 +51,8 @@ func assertPeggyVoucher(s sdk.Coin) {
 // VoucherDenom is a unique denominator and identifier for a bridged token.
 type VoucherDenom string
 
-func NewVoucherDenom(contractAddr, symbol string) VoucherDenom {
-	denomTrace := fmt.Sprintf("%s/%s/", contractAddr, symbol)
+func NewVoucherDenom(tokenContractAddr EthereumAddress, symbol string) VoucherDenom {
+	denomTrace := fmt.Sprintf("%s/%s/", tokenContractAddr.String(), symbol)
 	var hash tmbytes.HexBytes = tmhash.Sum([]byte(denomTrace))
 	simpleVoucherDenom := VoucherDenomPrefix + DenomSeparator + hash.String()
 	sdkVersionHackDenom := strings.ToLower(simpleVoucherDenom[0:15]) // todo: up to 15 chars (lowercase) allowed in this sdk version only
@@ -60,11 +60,11 @@ func NewVoucherDenom(contractAddr, symbol string) VoucherDenom {
 }
 
 // AsVoucherDenom type conversion with `IsVoucherDenom` check.
-func AsVoucherDenom(s string) (VoucherDenom, error) {
-	if !IsVoucherDenom(s) {
+func AsVoucherDenom(raw string) (VoucherDenom, error) {
+	if !IsVoucherDenom(raw) {
 		return "", sdkerrors.Wrap(ErrInvalid, "not a voucher denom")
 	}
-	return VoucherDenom(s), nil
+	return VoucherDenom(raw), nil
 }
 func (d VoucherDenom) Unprefixed() string {
 	return string(d[voucherPrefixLen:])

--- a/module/x/peggy/types/pool.go
+++ b/module/x/peggy/types/pool.go
@@ -51,8 +51,8 @@ func assertPeggyVoucher(s sdk.Coin) {
 // VoucherDenom is a unique denominator and identifier for a bridged token.
 type VoucherDenom string
 
-func NewVoucherDenom(contractAddr, token string) VoucherDenom {
-	denomTrace := fmt.Sprintf("%s/%s/", contractAddr, token)
+func NewVoucherDenom(contractAddr, symbol string) VoucherDenom {
+	denomTrace := fmt.Sprintf("%s/%s/", contractAddr, symbol)
 	var hash tmbytes.HexBytes = tmhash.Sum([]byte(denomTrace))
 	simpleVoucherDenom := VoucherDenomPrefix + DenomSeparator + hash.String()
 	sdkVersionHackDenom := strings.ToLower(simpleVoucherDenom[0:15]) // todo: up to 15 chars (lowercase) allowed in this sdk version only
@@ -68,6 +68,10 @@ func AsVoucherDenom(s string) (VoucherDenom, error) {
 }
 func (d VoucherDenom) Unprefixed() string {
 	return string(d[voucherPrefixLen:])
+}
+
+func (d VoucherDenom) String() string {
+	return string(d)
 }
 
 // IsVoucherDenom verifies the given string matches the peggy voucher conditions


### PR DESCRIPTION
Adds
* Attestation for bridge deposits
* Attestation for bridge withdrawals
* Attestation for bridge Multisig set updates

Rest endpoint to query last observed `nonce` by claim type.

Supported claim types:
*	BridgeDeposit
*	BridgeWithdrawalBatch
*	BridgeMultiSigUpdate

Example:
```sh
curl http://localhost:1317/peggy/last_observed_nonce/BridgeMultiSigUpdate -H "Content-Type: application/json"
```

## Reviewer note
Code not tested with a local instance. There is currently no cli support for submission of **Claims**

