### PR TITLE
Use attestations for signed executables on ETH

### DIFF
--- a/module/contrib/local/fake_multisig_attestation.sh
+++ b/module/contrib/local/fake_multisig_attestation.sh
@@ -8,6 +8,12 @@ peggycli tx peggy valset-request --from validator --chain-id=testing -b block -y
 echo "## Query pending request nonce"
 nonce=$(peggycli q peggy pending-valset-request $(peggycli keys show validator -a) -o json | jq -r ".value.Nonce")
 
+echo "## Approve pending request"
+peggycli tx peggy approved valset-confirm  "$nonce" 0xb8662f35f9de8720424e82b232e8c98d15399490adae9ca993f5ef1dc4883690 --from validator --chain-id=testing -b block -y
+
+echo "## View attestations"
+peggycli q peggy attestation orchestrator_signed_multisig_update $nonce -o json | jq
+
 echo "## Submit observation"
 # chain id: 1
 # bridge contract address: 0x8858eeb3dfffa017d4bce9801d340d36cf895ccf

--- a/module/x/peggy/alias.go
+++ b/module/x/peggy/alias.go
@@ -26,8 +26,6 @@ type (
 	MsgSendToEth                       = types.MsgSendToEth
 	MsgRequestBatch                    = types.MsgRequestBatch
 	MsgConfirmBatch                    = types.MsgConfirmBatch
-	MsgBatchInChain                    = types.MsgBatchInChain
-	MsgEthDeposit                      = types.MsgEthDeposit
 	Keeper                             = keeper.Keeper
 	MsgSetEthAddress                   = types.MsgSetEthAddress
 	MsgValsetConfirm                   = types.MsgValsetConfirm

--- a/module/x/peggy/client/cli/attestation_tx.go
+++ b/module/x/peggy/client/cli/attestation_tx.go
@@ -55,7 +55,7 @@ func GetApprovedCmd(storeKey string, cdc *codec.Codec) *cobra.Command {
 func CmdSendETHDepositRequest(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "deposit [eth chain id] [eth contract address] [nonce] [cosmos receiver] [amount] [eth erc20 symbol] [eth erc20 contract addr] [eth sender address]",
-		Short: "Submit an eth event observed by an orchestrator",
+		Short: "Submit a claim that a deposit was made on the Ethereum side",
 		Args:  cobra.ExactArgs(8),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
@@ -106,7 +106,7 @@ func CmdSendETHDepositRequest(cdc *codec.Codec) *cobra.Command {
 func CmdSendETHWithdrawalRequest(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "withdrawal [eth chain id] [eth contract address] [nonce]",
-		Short: "Submit an eth event observed by an orchestrator",
+		Short: "Submit a claim that a withdrawal was executed on the Ethereum side",
 		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
@@ -141,7 +141,7 @@ func CmdSendETHWithdrawalRequest(cdc *codec.Codec) *cobra.Command {
 func CmdSendETHMultiSigRequest(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "multisig-update [eth chain id] [eth contract address] [nonce]",
-		Short: "Submit an eth event observed by an orchestrator",
+		Short: "Submit a claim that the 'multisig set' update was executed on the Ethereum side",
 		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
@@ -176,7 +176,7 @@ func CmdSendETHMultiSigRequest(cdc *codec.Codec) *cobra.Command {
 func CmdValsetConfirm(storeKey string, cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "valset-confirm [nonce] [eth private key]",
-		Short: "this is used by validators to sign a valset with a particular nonce if it exists",
+		Short: "Sign a `multisig set` update for given nonce with the Ethereum key and submit to cosmos side",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)

--- a/module/x/peggy/client/cli/tx.go
+++ b/module/x/peggy/client/cli/tx.go
@@ -64,7 +64,7 @@ func GetUnsafeTestingCmd() *cobra.Command {
 func CmdUpdateEthAddress(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "update-eth-addr [eth private key]",
-		Short: "update your eth address which will be used for peggy if you are a validator",
+		Short: "Update your Ethereum address which will be used for signing executables for the `multisig set`",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
@@ -111,7 +111,7 @@ func CmdUpdateEthAddress(cdc *codec.Codec) *cobra.Command {
 func CmdValsetRequest(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "valset-request",
-		Short: "request that the validators sign over the current valset",
+		Short: "Trigger a new `multisig set` update request on the cosmos side",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 			inBuf := bufio.NewReader(cmd.InOrStdin())
@@ -171,7 +171,7 @@ func CmdUnsafeETHAddr() *cobra.Command {
 func CmdWithdrawToETH(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "withdraw [from_key_or_cosmos_address] [to_eth_address] [amount] [bridge_fee]",
-		Short: "adds a new entry to the tx pool to withdraw an amount from the bridge contract",
+		Short: "Adds a new entry to the transaction pool to withdraw an amount from the Ethereum bridge contract",
 		Args:  cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
@@ -207,7 +207,7 @@ func CmdWithdrawToETH(cdc *codec.Codec) *cobra.Command {
 func CmdRequestBatch(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "build-batch [voucher_denom]",
-		Short: "build a new batch for pooled TX",
+		Short: "Build a new batch on the cosmos side for pooled withdrawal transactions",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)

--- a/module/x/peggy/client/cli/tx.go
+++ b/module/x/peggy/client/cli/tx.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"crypto/ecdsa"
 	"encoding/hex"
-	"fmt"
 	"log"
 
 	"github.com/cosmos/cosmos-sdk/types/errors"
@@ -38,6 +37,7 @@ func GetTxCmd(storeKey string, cdc *codec.Codec) *cobra.Command {
 		CmdValsetRequest(cdc),
 		CmdValsetConfirm(storeKey, cdc),
 		GetObservedCmd(cdc),
+		GetApprovedCmd(storeKey, cdc),
 		GetUnsafeTestingCmd(),
 	)...)
 
@@ -93,10 +93,10 @@ func CmdUpdateEthAddress(cdc *codec.Codec) *cobra.Command {
 			if !ok {
 				log.Fatal("error casting public key to ECDSA")
 			}
-			ethAddress := ethCrypto.PubkeyToAddress(*publicKeyECDSA).Hex()
+			ethAddress := ethCrypto.PubkeyToAddress(*publicKeyECDSA)
 
 			// Make the message
-			msg := types.NewMsgSetEthAddress(ethAddress, cosmosAddr, hex.EncodeToString(signature))
+			msg := types.NewMsgSetEthAddress(types.EthereumAddress(ethAddress), cosmosAddr, hex.EncodeToString(signature))
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err
@@ -121,52 +121,6 @@ func CmdValsetRequest(cdc *codec.Codec) *cobra.Command {
 			// Make the message
 			msg := types.NewMsgValsetRequest(cosmosAddr)
 
-			// Send it
-			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
-		},
-	}
-}
-
-func CmdValsetConfirm(storeKey string, cdc *codec.Codec) *cobra.Command {
-	return &cobra.Command{
-		Use:   "valset-confirm [nonce] [eth private key]",
-		Short: "this is used by validators to sign a valset with a particular nonce if it exists",
-		Args:  cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			inBuf := bufio.NewReader(cmd.InOrStdin())
-			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
-
-			// Make Eth Signature over valset
-			privKeyString := args[1][2:]
-			privateKey, err := ethCrypto.HexToECDSA(privKeyString)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			nonce := args[0]
-			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/valsetRequest/%s", storeKey, nonce), nil)
-			if err != nil {
-				fmt.Printf("could not get valset")
-				return nil
-			}
-
-			var valset types.Valset
-			cdc.MustUnmarshalJSON(res, &valset)
-			checkpoint := valset.GetCheckpoint()
-
-			signature, err := ethCrypto.Sign(checkpoint, privateKey)
-			if err != nil {
-				log.Fatal(err)
-			}
-			cosmosAddr := cliCtx.GetFromAddress()
-			// Make the message
-			msg := types.NewMsgValsetConfirm(valset.Nonce, cosmosAddr, hex.EncodeToString(signature))
-
-			err = msg.ValidateBasic()
-			if err != nil {
-				return err
-			}
 			// Send it
 			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
 		},

--- a/module/x/peggy/client/rest/rest.go
+++ b/module/x/peggy/client/rest/rest.go
@@ -27,4 +27,7 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) 
 	r.HandleFunc(fmt.Sprintf("/%s/pending_valset_requests/{%s}", storeName, bech32ValidatorAddress), lastValsetRequestsByAddressHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/last_observed_nonce/{%s}", storeName, claimType), lastObservedNonceHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/last_observed_nonces", storeName), lastObservedNoncesHandler(cliCtx, storeName)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/last_observed_valset", storeName), lastObservedValsetHandler(cliCtx, storeName)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/last_approved_valset", storeName), lastApprovedValsetHandler(cliCtx, storeName)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/attestation/{%s}/{%s}", storeName, claimType, nonce), queryAttestation(cliCtx, storeName)).Methods("GET")
 }

--- a/module/x/peggy/client/rest/tx.go
+++ b/module/x/peggy/client/rest/tx.go
@@ -62,7 +62,7 @@ func updateEthAddressHandler(cliCtx context.CLIContext) http.HandlerFunc {
 		// Make the message, we convert the recovered address into a string
 		// so at this point we have verified that this address signed this
 		// cosmos address
-		msg := types.NewMsgSetEthAddress(ethAddr.String(), cosmosAddr, hex.EncodeToString(ethSig))
+		msg := types.NewMsgSetEthAddress(types.EthereumAddress(ethAddr), cosmosAddr, hex.EncodeToString(ethSig))
 		err = msg.ValidateBasic()
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/module/x/peggy/keeper/attestation.go
+++ b/module/x/peggy/keeper/attestation.go
@@ -94,9 +94,9 @@ func (k Keeper) tryAttestation(ctx sdk.Context, claimType types.ClaimType, nonce
 			ProcessResult: types.ProcessResultUnknown,
 			Details:       details,
 			Tally: types.AttestationTally{
-				TotalVotesPower:     zero,
+				TotalVotesPower:    zero,
 				RequiredVotesPower: types.AttestationVotesPowerThreshold.MulUint64(power.Uint64()).Quo(hundred),
-				RequiredVotesCount:  types.AttestationVotesCountThreshold.MulUint64(uint64(count)).Quo(hundred).Uint64(),
+				RequiredVotesCount: types.AttestationVotesCountThreshold.MulUint64(uint64(count)).Quo(hundred).Uint64(),
 			},
 			SubmitTime:          now,
 			ConfirmationEndTime: now.Add(types.AttestationPeriod),

--- a/module/x/peggy/keeper/attestation.go
+++ b/module/x/peggy/keeper/attestation.go
@@ -94,9 +94,9 @@ func (k Keeper) tryAttestation(ctx sdk.Context, claimType types.ClaimType, nonce
 			ProcessResult: types.ProcessResultUnknown,
 			Details:       details,
 			Tally: types.AttestationTally{
-				TotalVotesPower:    zero,
+				TotalVotesPower:     zero,
 				RequiredVotesPower: types.AttestationVotesPowerThreshold.MulUint64(power.Uint64()).Quo(hundred),
-				RequiredVotesCount: types.AttestationVotesCountThreshold.MulUint64(uint64(count)).Quo(hundred).Uint64(),
+				RequiredVotesCount:  types.AttestationVotesCountThreshold.MulUint64(uint64(count)).Quo(hundred).Uint64(),
 			},
 			SubmitTime:          now,
 			ConfirmationEndTime: now.Add(types.AttestationPeriod),
@@ -145,15 +145,15 @@ func (k Keeper) IterateAttestationByClaimTypeDesc(ctx sdk.Context, claimType typ
 	return
 }
 
-// GetLastObservedNonce returns nonce or nil when none found for given type
-func (k Keeper) GetLastObservedNonce(ctx sdk.Context, claimType types.ClaimType) types.Nonce {
-	var nonce types.Nonce
+// GetLastObservedAttestation returns attestation for given claim type  or nil when none found
+func (k Keeper) GetLastObservedAttestation(ctx sdk.Context, claimType types.ClaimType) *types.Attestation {
+	var result *types.Attestation
 	k.IterateAttestationByClaimTypeDesc(ctx, claimType, func(_ []byte, att types.Attestation) bool {
 		if att.Certainty != types.CertaintyObserved {
 			return false
 		}
-		nonce = att.Nonce
+		result = &att
 		return true
 	})
-	return nonce
+	return result
 }

--- a/module/x/peggy/keeper/attestation_handler.go
+++ b/module/x/peggy/keeper/attestation_handler.go
@@ -66,6 +66,22 @@ func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation) error
 			return false
 		})
 		return nil
+	case types.ClaimTypeOrchestratorSignedMultiSigUpdate:
+		signedCheckpoint, ok := att.Details.(types.SignedCheckpoint)
+		if !ok {
+			return sdkerrors.Wrapf(types.ErrInvalid, "unexpected type: %T", att.Details)
+		}
+		_ = signedCheckpoint
+		// todo: any cleanup to do? delete all valsets with nonce < last observed one?
+		return nil
+	case types.ClaimTypeOrchestratorSignedWithdrawBatch:
+		signedCheckpoint, ok := att.Details.(types.SignedCheckpoint)
+		if !ok {
+			return sdkerrors.Wrapf(types.ErrInvalid, "unexpected type: %T", att.Details)
+		}
+		_ = signedCheckpoint
+		// todo: any cleanup to do? delete all withdraw batches with nonce < last observed one?
+		return nil
 	default:
 		return sdkerrors.Wrapf(types.ErrInvalid, "event type: %s", att.ClaimType)
 	}

--- a/module/x/peggy/keeper/batch.go
+++ b/module/x/peggy/keeper/batch.go
@@ -116,14 +116,16 @@ func (k Keeper) CancelOutgoingTXBatch(ctx sdk.Context, batchID uint64) error {
 	return nil
 }
 
+// SetOutgoingTXBatchConfirm stores the signature an orchestrator has submitted for an outgoing batch
 func (k Keeper) SetOutgoingTXBatchConfirm(ctx sdk.Context, batchID uint64, validator sdk.ValAddress, signature []byte) {
 	store := ctx.KVStore(k.storeKey)
 	store.Set(types.GetOutgoingTXBatchConfirmKey(batchID, validator), signature)
 }
 
-func (k Keeper) HasOutgoingTXBatchConfirm(ctx sdk.Context, nonce uint64, validatorAddr sdk.ValAddress) bool {
+// HasOutgoingTXBatchConfirm returns true when a signature was persisted for the given batch and validator address
+func (k Keeper) HasOutgoingTXBatchConfirm(ctx sdk.Context, batchID uint64, validatorAddr sdk.ValAddress) bool {
 	store := ctx.KVStore(k.storeKey)
-	return store.Has(types.GetOutgoingTXBatchConfirmKey(nonce, validatorAddr))
+	return store.Has(types.GetOutgoingTXBatchConfirmKey(batchID, validatorAddr))
 }
 
 // Iterate through all outgoing batches in DESC order.

--- a/module/x/peggy/keeper/querier_test.go
+++ b/module/x/peggy/keeper/querier_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/althea-net/peggy/module/x/peggy/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	gethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -128,8 +129,7 @@ func TestLastValsetRequestNonces(t *testing.T) {
 		for j := 0; j <= i; j++ {
 			// add an validator each block
 			valAddr := bytes.Repeat([]byte{byte(j)}, sdk.AddrLen)
-			ethAddr := fmt.Sprintf("my eth addr %d", j+1)
-			k.SetEthAddress(ctx, valAddr, ethAddr)
+			k.SetEthAddress(ctx, valAddr, createEthAddress(j+1))
 			validators = append(validators, valAddr)
 		}
 		k.StakingKeeper = NewStakingKeeperMock(validators...)
@@ -153,12 +153,12 @@ func TestLastValsetRequestNonces(t *testing.T) {
 	  "100"
 	],
 	"EthAddresses": [
-	  "my eth addr 1",
-	  "my eth addr 2",
-	  "my eth addr 3",
-	  "my eth addr 4",
-	  "my eth addr 5",
-	  "my eth addr 6"
+	  "0x0101010101010101010101010101010101010101",
+	  "0x0202020202020202020202020202020202020202",
+	  "0x0303030303030303030303030303030303030303",
+	  "0x0404040404040404040404040404040404040404",
+	  "0x0505050505050505050505050505050505050505",
+	  "0x0606060606060606060606060606060606060606"
 	]
   },
   {
@@ -171,11 +171,11 @@ func TestLastValsetRequestNonces(t *testing.T) {
 	  "100"
 	],
 	"EthAddresses": [
-	  "my eth addr 1",
-	  "my eth addr 2",
-	  "my eth addr 3",
-	  "my eth addr 4",
-	  "my eth addr 5"
+	  "0x0101010101010101010101010101010101010101",
+	  "0x0202020202020202020202020202020202020202",
+	  "0x0303030303030303030303030303030303030303",
+	  "0x0404040404040404040404040404040404040404",
+	  "0x0505050505050505050505050505050505050505"
 	]
   },
   {
@@ -187,10 +187,10 @@ func TestLastValsetRequestNonces(t *testing.T) {
 	  "100"
 	],
 	"EthAddresses": [
-	  "my eth addr 1",
-	  "my eth addr 2",
-	  "my eth addr 3",
-	  "my eth addr 4"
+	  "0x0101010101010101010101010101010101010101",
+	  "0x0202020202020202020202020202020202020202",
+	  "0x0303030303030303030303030303030303030303",
+	  "0x0404040404040404040404040404040404040404"
 	]
   },
   {
@@ -201,9 +201,9 @@ func TestLastValsetRequestNonces(t *testing.T) {
 	  "100"
 	],
 	"EthAddresses": [
-	  "my eth addr 1",
-	  "my eth addr 2",
-	  "my eth addr 3"
+	  "0x0101010101010101010101010101010101010101",
+	  "0x0202020202020202020202020202020202020202",
+	  "0x0303030303030303030303030303030303030303"
 	]
   },
   {
@@ -213,8 +213,8 @@ func TestLastValsetRequestNonces(t *testing.T) {
 	  "100"
 	],
 	"EthAddresses": [
-	  "my eth addr 1",
-	  "my eth addr 2"
+	  "0x0101010101010101010101010101010101010101",
+	  "0x0202020202020202020202020202020202020202"
 	]
   }
 ]`),
@@ -228,6 +228,7 @@ func TestLastValsetRequestNonces(t *testing.T) {
 		})
 	}
 }
+
 func TestLastPendingValsetRequest(t *testing.T) {
 	k, ctx, _ := CreateTestEnv(t)
 	var (
@@ -306,4 +307,9 @@ func TestLastPendingValsetRequest(t *testing.T) {
 			assert.JSONEq(t, string(spec.expResp), string(got), string(got))
 		})
 	}
+}
+
+func createEthAddress(i int) types.EthereumAddress {
+	return types.EthereumAddress(gethCommon.BytesToAddress(bytes.Repeat([]byte{byte(i)}, 20)))
+
 }

--- a/module/x/peggy/types/codec.go
+++ b/module/x/peggy/types/codec.go
@@ -34,6 +34,9 @@ func RegisterCodec(cdc *codec.Codec) {
 
 	cdc.RegisterConcrete(BridgedDenominator{}, "peggy/BridgedDenominator", nil)
 	cdc.RegisterConcrete(IDSet{}, "peggy/IDSet", nil)
+
+	cdc.RegisterConcrete(Attestation{}, "peggy/Attestation", nil)
 	cdc.RegisterInterface((*AttestationDetails)(nil), nil)
 	cdc.RegisterConcrete(BridgeDeposit{}, "peggy/BridgeDeposit", nil)
+	cdc.RegisterConcrete(SignedCheckpoint{}, "peggy/SignedCheckpoint", nil)
 }

--- a/module/x/peggy/types/events.go
+++ b/module/x/peggy/types/events.go
@@ -3,12 +3,14 @@ package types
 const (
 	EventTypeObservation              = "observation"
 	EventTypeOutgoingBatch            = "outgoing_batch"
+	EventTypeMultisigUpdateRequest    = "multisig_update_request"
 	EventTypeOutgoingBatchCanceled    = "outgoing_batch_canceled"
 	EventTypeBridgeWithdrawalReceived = "withdrawal_received"
 	EventTypeBridgeDepositReceived    = "deposit_received"
 )
 const (
 	AttributeKeyAttestationID   = "attestation_id"
+	AttributeKeyMultisigID      = "multisig_id"
 	AttributeKeyOutgoingBatchID = "batch_id"
 	AttributeKeyOutgoingTXID    = "outgoing_tx_id"
 	AttributeKeyAttestationType = "attestation_type"

--- a/module/x/peggy/types/key.go
+++ b/module/x/peggy/types/key.go
@@ -38,7 +38,7 @@ var (
 	KeyLastOutgoingBatchID = append(SequenceKeyPrefix, []byte("lastBatchId")...)
 )
 
-func GetEthAddressKey(validator sdk.AccAddress) []byte {
+func GetEthAddressKey(validator sdk.ValAddress) []byte {
 	return append(EthAddressKey, []byte(validator)...)
 }
 

--- a/module/x/peggy/types/pool.go
+++ b/module/x/peggy/types/pool.go
@@ -18,12 +18,17 @@ type OutgoingTx struct {
 	BridgeFee   sdk.Coin        `json:"bridge_fee"`
 }
 
-// BridgedDenominator contains bridged token details
+// BridgedDenominator track and identify the ported ERC20 tokens into Peggy.
+// An ERC20 token on the Ethereum side can be uniquely identified by the ERC20 contract address and the human readable symbol
+// used for it in the contract
+// In Peggy this is represented as "vouchers" that get minted and burned when interacting with the Ethereum side. These "vouchers"
+// are identified by a prefixed string representation. See VoucherDenom type.
 type BridgedDenominator struct {
-	//ChainID         string
+	// TokenContractAddress is the ERC20 contract address
 	TokenContractAddress EthereumAddress
-	// Symbol is the human readable erc20 symbol
-	Symbol             string
+	// Symbol is the human readable ERC20 token name.
+	Symbol string
+	// CosmosVoucherDenom is used as denom in sdk.Coin
 	CosmosVoucherDenom VoucherDenom
 }
 
@@ -72,10 +77,10 @@ func assertPeggyVoucher(s sdk.Coin) {
 	}
 }
 
-// VoucherDenom is a unique denominator and identifier for a bridged token.
+// VoucherDenom is a unique denominator and identifier for an ERC20 token in the cosmos world
 type VoucherDenom string
 
-// NewVoucherDenom builds a Peggy voucher denominator from the erc20 contract address and the human readable erc20 symbol.
+// NewVoucherDenom builds a Peggy voucher denominator from the ERC20 contract address and the human readable ERC20 symbol.
 func NewVoucherDenom(tokenContractAddr EthereumAddress, erc20Symbol string) VoucherDenom {
 	denomTrace := fmt.Sprintf("%s/%s/", tokenContractAddr.String(), erc20Symbol)
 	var hash tmbytes.HexBytes = tmhash.Sum([]byte(denomTrace))
@@ -104,5 +109,5 @@ func IsVoucherDenom(denom string) bool {
 	return len(denom) == VoucherDenomLen && strings.HasPrefix(denom, VoucherDenomPrefix)
 }
 
-// IDSet is a collection of DB keys
+// IDSet is a collection of DB keys in a second index.
 type IDSet []uint64


### PR DESCRIPTION
Focus on Multisig Set update (valset update) confimations.

Reviewer notes:
* Batch confirmations not implemented in rest/ cli
* Current validator set is also used for threshold calculation NOT the Multisig Set
* Only minimal REST endpoints/ cli commands 
* Only minimal tests 🙈 
* Mixed `Nonce` types are still used (bytes, int64, uin64, base64 encoded bytes)
* Very early version

### New REST endpoints:
* Query an attestation by type:

```sh
curl http://localhost:1317/peggy/attestation/orchestrator_signed_multisig_update/459 -H "Content-Type: application/json"

# base64 encoded nonce
curl http://localhost:1317/peggy/attestation/orchestrator_signed_multisig_update/AAAAAAAAAcs= -H "Content-Type: application/json"
```
Example response:
```json
{
  "height": "1314",
  "result": {
    "type": "peggy/Attestation",
    "value": {
      "ClaimType": "orchestrator_signed_multisig_update",
      "Nonce": "AAAAAAAAAcs=",
      "Certainty": 2,
      "Status": 2,
      "ProcessResult": 1,
      "Tally": {
        "TotalVotesPower": "1000",
        "TotalVotesCount": "1",
        "RequiredVotesPower": "660",
        "RequiredVotesCount": "0"
      },
      "SubmitTime": "2020-09-23T10:41:04.293295Z",
      "ConfirmationEndTime": "2020-09-24T10:41:04.293295Z",
      "Details": {
        "type": "peggy/SignedCheckpoint",
        "value": {
          "Checkpoint": "TD/dTEyDdx3frEcwWI49yDSYx4gM1ic9D+TJqA5dZ94="
        }
      }
    }
  }
}
```



* Query the last multisig set that was observed by >66% of the validators
```sh
curl http://localhost:1317/peggy/last_observed_valset -H "Content-Type: application/json"
```
* Query the last multisig set update (for execution on ETH) that was signed by >66% of the validators
```sh
curl http://localhost:1317/peggy/last_approved_valset -H "Content-Type: application/json"
```
Example Response:
```json
{
  "height": "1129",
  "result": {
    "Checkpoint": "R5Hd7QcEEy1v20m5ALj3XJ4expMYyb/qROvHMIF1cvA=",
    "Signatures": [
      "383aee693de33f9450f296f4028ace5c11f2a6c8e141a7722cda902e0d443a716deddbd7a935804651bf986b85db2c8acf12cd469d384035385072e439e956fd00"
    ],
    "Valset": {
      "EthAddresses": [
        "0xb462864E395d88d6bc7C5dd5F3F5eb4cc2599255"
      ],
      "Nonce": "664",
      "Powers": [
        "1000"
      ]
    }
  }
}
```