### PR TITLE
Fix signature order

### DIFF
--- a/module/contrib/local/01-bootstrap_attestation.sh
+++ b/module/contrib/local/01-bootstrap_attestation.sh
@@ -15,8 +15,8 @@ nonce=$(date +%s)  # use unix timestamp as fake nonce
 peggycli tx peggy observed bootstrap 1 0x8858eeb3dfffa017d4bce9801d340d36cf895ccf  "$nonce" "0xc783df8a850f42e7f7e57013759c285caa701eb6"  "10" my-peggy-id  0 --from validator --chain-id=testing -b block -y
 
 echo "## View attestation status"
-peggycli q peggy attestation bridge_bootstrap "$nonce" -o json
+peggycli q peggy attestation bridge_bootstrap "$nonce" -o json | jq
 
 echo "## Query last observed state"
-peggycli q peggy observed nonces -o json
+peggycli q peggy observed nonces -o json | jq
 

--- a/module/contrib/local/02-fake_deposit_attestation.sh
+++ b/module/contrib/local/02-fake_deposit_attestation.sh
@@ -15,6 +15,6 @@ nonce=$(date +%s)  # use unix timestamp as fake nonce
 peggycli tx peggy observed deposit 1 0x8858eeb3dfffa017d4bce9801d340d36cf895ccf  "$nonce" $(peggycli keys show validator -a)  1000 ALX 0xc783df8a850f42e7f7e57013759c285caa701eb6 0x7c2c195cd6d34b8f845992d380aadb2730bb9c6f --from validator --chain-id=testing -b block -y
 
 echo "## Query balance"
-peggycli q account cosmos12flmaejjvzdtz58s4m5avx30wm8uffe7ycj4l9
+peggycli q account $(peggycli keys show validator -a)
 echo "## Query last observed state"
 peggycli q peggy observed nonces -o json

--- a/module/contrib/local/03-fake_withdraw_attestation.sh
+++ b/module/contrib/local/03-fake_withdraw_attestation.sh
@@ -23,6 +23,6 @@ echo "## Submit observation"
 peggycli tx peggy observed withdrawal 1 0x8858eeb3dfffa017d4bce9801d340d36cf895ccf  "$nonce" --from validator --chain-id=testing -b block -y
 
 echo "## Query balance"
-peggycli q account cosmos12flmaejjvzdtz58s4m5avx30wm8uffe7ycj4l9
+peggycli q account $(peggycli keys show validator -a)
 echo "## Query last observed state"
 peggycli q peggy observed nonces -o json

--- a/module/x/peggy/client/cli/attestation_tx.go
+++ b/module/x/peggy/client/cli/attestation_tx.go
@@ -320,6 +320,7 @@ func CmdOutgointTXBatchConfirm(storeKey string, cdc *codec.Codec) *cobra.Command
 			if err != nil {
 				return err
 			}
+
 			if len(res) == 0 {
 				return ErrNotFound
 			}

--- a/module/x/peggy/handler.go
+++ b/module/x/peggy/handler.go
@@ -72,7 +72,7 @@ func handleMsgValsetRequest(ctx sdk.Context, keeper Keeper, msg types.MsgValsetR
 	// todo: is requester in current valset?\
 
 	// disabling bootstrap check for integration tests to pass
-	//if keeper.GetLastValsetObservedNonce(ctx).IsEmpty() {
+	//if keeper.GetLastValsetObservedNonce(ctx).isValid() {
 	//	return nil, sdkerrors.Wrap(types.ErrInvalid, "bridge bootstrap process not observed, yet")
 	//}
 	v := keeper.SetValsetRequest(ctx)

--- a/module/x/peggy/keeper/attestation.go
+++ b/module/x/peggy/keeper/attestation.go
@@ -62,7 +62,7 @@ func (k Keeper) processAttestation(ctx sdk.Context, att *types.Attestation) erro
 	// then execute in a new Tx so that we can store state on failure
 	xCtx, commit := ctx.CacheContext()
 	if err := k.AttestationHandler.Handle(xCtx, *att); err != nil { // execute with a transient storage
-		ctx.Logger().Error("attestation failed", "cause", err.Error(), "claim type", att.ClaimType, "id", att.ID(), "nonce", att.Nonce.String())
+		k.logger(ctx).Error("attestation failed", "cause", err.Error(), "claim type", att.ClaimType, "id", att.ID(), "nonce", att.Nonce.String())
 		att.ProcessResult = types.ProcessResultFailure
 	} else {
 		att.ProcessResult = types.ProcessResultSuccess

--- a/module/x/peggy/keeper/attestation_handler.go
+++ b/module/x/peggy/keeper/attestation_handler.go
@@ -41,7 +41,7 @@ func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation) error
 		if err := b.Observed(); err != nil {
 			return err
 		}
-		a.keeper.storeBatch(ctx, att.Nonce, *b)
+		a.keeper.storeBatch(ctx, *b)
 		// cleanup outgoing TX pool
 		for i := range b.Elements {
 			a.keeper.removePoolEntry(ctx, b.Elements[i].ID)
@@ -80,7 +80,7 @@ func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation) error
 		// todo: do we want to do a sanity check that these validator addresses exits already?
 		// the peggy bridge can not operate proper without orchestrators having their ethereum
 		// addresses set before.
-		return a.keeper.SetBootstrapValset(ctx, att.Nonce, initialMultisigSet)
+		return a.keeper.SetBootstrapValset(ctx, initialMultisigSet)
 	case types.ClaimTypeOrchestratorSignedMultiSigUpdate:
 		signedCheckpoint, ok := att.Details.(types.SignedCheckpoint)
 		if !ok {

--- a/module/x/peggy/keeper/batch.go
+++ b/module/x/peggy/keeper/batch.go
@@ -42,7 +42,7 @@ func (k Keeper) BuildOutgoingTXBatch(ctx sdk.Context, voucherDenom types.Voucher
 		TotalFee:           totalFee,
 		BatchStatus:        types.BatchStatusPending,
 	}
-	k.storeBatch(ctx, nonce, batch)
+	k.storeBatch(ctx, batch)
 
 	batchEvent := sdk.NewEvent(
 		types.EventTypeOutgoingBatch,
@@ -56,9 +56,9 @@ func (k Keeper) BuildOutgoingTXBatch(ctx sdk.Context, voucherDenom types.Voucher
 	return &batch, nil
 }
 
-func (k Keeper) storeBatch(ctx sdk.Context, nonce types.UInt64Nonce, batch types.OutgoingTxBatch) {
+func (k Keeper) storeBatch(ctx sdk.Context, batch types.OutgoingTxBatch) {
 	store := ctx.KVStore(k.storeKey)
-	store.Set(types.GetOutgoingTxBatchKey(nonce), k.cdc.MustMarshalBinaryBare(batch))
+	store.Set(types.GetOutgoingTxBatchKey(batch.Nonce), k.cdc.MustMarshalBinaryBare(batch))
 }
 
 // pickUnbatchedTX find TX in pool and remove from "available" second index
@@ -104,7 +104,7 @@ func (k Keeper) CancelOutgoingTXBatch(ctx sdk.Context, nonce types.UInt64Nonce) 
 	for _, tx := range batch.Elements {
 		k.prependToUnbatchedTXIndex(ctx, batch.BridgedDenominator.ToVoucherCoin(tx.BridgeFee.Amount), tx.ID)
 	}
-	k.storeBatch(ctx, nonce, *batch)
+	k.storeBatch(ctx, *batch)
 	batchEvent := sdk.NewEvent(
 		types.EventTypeOutgoingBatchCanceled,
 		sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),

--- a/module/x/peggy/keeper/keeper_test.go
+++ b/module/x/peggy/keeper/keeper_test.go
@@ -50,8 +50,8 @@ func TestCurrentValsetNormalization(t *testing.T) {
 			expPowers: []uint64{4294967295},
 		},
 		"two": {
-			srcPowers: []uint64{1, 100},
-			expPowers: []uint64{42524428, 4252442866},
+			srcPowers: []uint64{100, 1},
+			expPowers: []uint64{4252442866, 42524428},
 		},
 	}
 	k, ctx, _ := CreateTestEnv(t)

--- a/module/x/peggy/keeper/querier_test.go
+++ b/module/x/peggy/keeper/querier_test.go
@@ -10,6 +10,7 @@ import (
 	gethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/crypto/secp256k1"
 )
 
 func TestQueryValsetConfirm(t *testing.T) {
@@ -344,7 +345,298 @@ func TestLastPendingValsetRequest(t *testing.T) {
 	}
 }
 
+func TestLastApprovedMultiSigUpdate(t *testing.T) {
+	const maxVal = 3
+	validators := make(map[string]types.BridgeValidator, maxVal)
+	validatorAddrs := make([]sdk.ValAddress, maxVal+1)
+	sigs := make(map[string][]byte, maxVal)
+
+	// some validator/ orchestrator test data
+	for i := 0; i < maxVal; i++ {
+		n := i + 1
+		validatorAddrs[n] = createValAddress()
+		valAddr := validatorAddrs[n].String()
+		validators[valAddr] = types.BridgeValidator{
+			Power:           uint64(n),
+			EthereumAddress: createEthAddress(n),
+		}
+		sigs[valAddr] = createFakeEthSignature(n)
+	}
+	unsortedOrchestrators := make(types.BridgeValidators, 0, maxVal)
+	for _, v := range validators {
+		unsortedOrchestrators = append(unsortedOrchestrators, v)
+	}
+	nonce := types.NewUInt64Nonce(1)
+
+	specs := map[string]struct {
+		srcBridgedVal types.BridgeValidators
+		srcSigners    map[types.EthereumAddress]sdk.ValAddress
+		expResp       *MultiSigUpdateResponse
+	}{
+
+		"validators and sigs ordered by power": {
+			srcBridgedVal: []types.BridgeValidator{
+				{Power: 1, EthereumAddress: createEthAddress(1)},
+				{Power: 2, EthereumAddress: createEthAddress(2)},
+				{Power: 3, EthereumAddress: createEthAddress(3)},
+			},
+			srcSigners: map[types.EthereumAddress]sdk.ValAddress{
+				createEthAddress(1): validatorAddrs[1],
+				createEthAddress(2): validatorAddrs[2],
+				createEthAddress(3): validatorAddrs[3],
+			},
+			expResp: &MultiSigUpdateResponse{
+				Valset: types.Valset{
+					Nonce: nonce,
+					Members: types.BridgeValidators{
+						{Power: 3, EthereumAddress: createEthAddress(3)},
+						{Power: 2, EthereumAddress: createEthAddress(2)},
+						{Power: 1, EthereumAddress: createEthAddress(1)},
+					},
+				},
+				Signatures: [][]byte{
+					createFakeEthSignature(3),
+					createFakeEthSignature(2),
+					createFakeEthSignature(1),
+				},
+			},
+		},
+		"validators with power 0 excluded": {
+			srcBridgedVal: []types.BridgeValidator{
+				{Power: 0, EthereumAddress: createEthAddress(1)},
+				{Power: 2, EthereumAddress: createEthAddress(2)},
+			},
+			srcSigners: map[types.EthereumAddress]sdk.ValAddress{
+				createEthAddress(2): validatorAddrs[2],
+			},
+			expResp: &MultiSigUpdateResponse{
+				Valset: types.Valset{
+					Nonce: nonce,
+					Members: types.BridgeValidators{
+						{Power: 2, EthereumAddress: createEthAddress(2)},
+					},
+				},
+				Signatures: [][]byte{
+					createFakeEthSignature(2),
+				},
+			},
+		},
+		"validators not in current mutliSig set excluded": {
+			srcBridgedVal: []types.BridgeValidator{
+				{Power: 1, EthereumAddress: createEthAddress(1)},
+			},
+			srcSigners: map[types.EthereumAddress]sdk.ValAddress{
+				createEthAddress(1):   validatorAddrs[1],
+				createEthAddress(999): validatorAddrs[0],
+			},
+			expResp: &MultiSigUpdateResponse{
+				Valset: types.Valset{
+					Nonce: nonce,
+					Members: types.BridgeValidators{
+						{Power: 1, EthereumAddress: createEthAddress(1)},
+					},
+				},
+				Signatures: [][]byte{
+					createFakeEthSignature(1),
+				},
+			},
+		},
+		"without signatures": {
+			srcBridgedVal: []types.BridgeValidator{
+				{Power: 1, EthereumAddress: createEthAddress(1)},
+			},
+			expResp: &MultiSigUpdateResponse{
+				Valset: types.Valset{Nonce: nonce, Members: types.BridgeValidators{{Power: 1, EthereumAddress: createEthAddress(1)}}},
+			},
+		},
+	}
+	for msg, spec := range specs {
+		t.Run(msg, func(t *testing.T) {
+			k, ctx, _ := CreateTestEnv(t)
+			// persist multiSig set as latest observed
+			k.storeValset(ctx, types.NewValset(nonce, spec.srcBridgedVal))
+			k.setLastAttestedNonce(ctx, types.ClaimTypeEthereumBridgeMultiSigUpdate, nonce)
+			// store approved attestation
+			k.setLastAttestedNonce(ctx, types.ClaimTypeOrchestratorSignedMultiSigUpdate, nonce)
+			// with all the orchestrator's signatures stored
+			for ethAddr, valAddr := range spec.srcSigners {
+				k.SetEthAddress(ctx, valAddr, ethAddr)
+				if sig, ok := sigs[valAddr.String()]; ok {
+					k.SetBridgeApprovalSignature(ctx, types.ClaimTypeOrchestratorSignedMultiSigUpdate, nonce, valAddr, sig)
+				}
+			}
+
+			// when
+			bz, err := lastApprovedMultiSigUpdate(ctx, k)
+
+			// then
+			require.NoError(t, err)
+			if spec.expResp == nil {
+				require.Nil(t, bz)
+				return
+			}
+			require.NotNil(t, bz)
+
+			var got MultiSigUpdateResponse
+			k.cdc.MustUnmarshalJSON(bz, &got)
+
+			assert.Equal(t, *spec.expResp, got)
+		})
+	}
+}
+
+func TestQueryInflightBatches(t *testing.T) {
+	const maxVal = 3
+	validators := make(map[string]types.BridgeValidator, maxVal)
+	validatorAddrs := make([]sdk.ValAddress, maxVal+1)
+	sigs := make(map[string][]byte, maxVal)
+
+	// some validator/ orchestrator test data
+	for i := 0; i < maxVal; i++ {
+		n := i + 1
+		validatorAddrs[n] = createValAddress()
+		valAddr := validatorAddrs[n].String()
+		validators[valAddr] = types.BridgeValidator{
+			Power:           uint64(n),
+			EthereumAddress: createEthAddress(n),
+		}
+		sigs[valAddr] = createFakeEthSignature(n)
+	}
+	unsortedOrchestrators := make(types.BridgeValidators, 0, maxVal)
+	for _, v := range validators {
+		unsortedOrchestrators = append(unsortedOrchestrators, v)
+	}
+	var (
+		nonce = types.NewUInt64Nonce(1)
+		batch = types.OutgoingTxBatch{Nonce: nonce}
+	)
+
+	specs := map[string]struct {
+		srcBridgedVal     types.BridgeValidators
+		srcSigners        map[types.EthereumAddress]sdk.ValAddress
+		lastObservedBatch types.UInt64Nonce
+		expResp           []ApprovedOutgoingTxBatchResponse
+	}{
+		"validators and sigs ordered by power": {
+			srcBridgedVal: []types.BridgeValidator{
+				{Power: 1, EthereumAddress: createEthAddress(1)},
+				{Power: 2, EthereumAddress: createEthAddress(2)},
+				{Power: 3, EthereumAddress: createEthAddress(3)},
+			},
+			srcSigners: map[types.EthereumAddress]sdk.ValAddress{
+				createEthAddress(1): validatorAddrs[1],
+				createEthAddress(2): validatorAddrs[2],
+				createEthAddress(3): validatorAddrs[3],
+			},
+			lastObservedBatch: types.NewUInt64Nonce(0),
+
+			expResp: []ApprovedOutgoingTxBatchResponse{
+				{
+					Batch: batch,
+					Signatures: [][]byte{
+						createFakeEthSignature(3),
+						createFakeEthSignature(2),
+						createFakeEthSignature(1),
+					},
+				},
+			},
+		},
+		"validators with power 0 excluded": {
+			srcBridgedVal: []types.BridgeValidator{
+				{Power: 0, EthereumAddress: createEthAddress(1)},
+				{Power: 2, EthereumAddress: createEthAddress(2)},
+			},
+			srcSigners: map[types.EthereumAddress]sdk.ValAddress{
+				createEthAddress(2): validatorAddrs[2],
+			},
+			expResp: []ApprovedOutgoingTxBatchResponse{
+				{
+					Batch: batch,
+					Signatures: [][]byte{
+						createFakeEthSignature(2),
+					},
+				},
+			},
+		},
+		"validators not in current mutliSig set excluded": {
+			srcBridgedVal: []types.BridgeValidator{
+				{Power: 1, EthereumAddress: createEthAddress(1)},
+			},
+			srcSigners: map[types.EthereumAddress]sdk.ValAddress{
+				createEthAddress(1):   validatorAddrs[1],
+				createEthAddress(999): validatorAddrs[0],
+			},
+			expResp: []ApprovedOutgoingTxBatchResponse{
+				{
+					Batch: batch,
+					Signatures: [][]byte{
+						createFakeEthSignature(1),
+					},
+				},
+			},
+		},
+		"without signatures": {
+			srcBridgedVal: []types.BridgeValidator{
+				{Power: 1, EthereumAddress: createEthAddress(1)},
+			},
+			expResp: []ApprovedOutgoingTxBatchResponse{
+				{Batch: batch},
+			},
+		},
+		"nothing in flight": {
+			srcBridgedVal: []types.BridgeValidator{
+				{Power: 1, EthereumAddress: createEthAddress(1)},
+			},
+			lastObservedBatch: nonce,
+		},
+	}
+	for msg, spec := range specs {
+		t.Run(msg, func(t *testing.T) {
+			k, ctx, _ := CreateTestEnv(t)
+			// persist multiSig set
+			k.storeValset(ctx, types.NewValset(nonce, spec.srcBridgedVal))
+			k.setLastAttestedNonce(ctx, types.ClaimTypeEthereumBridgeMultiSigUpdate, nonce)
+			// persist batch
+			k.storeBatch(ctx, batch)
+			// store an approved attestation
+			if !spec.lastObservedBatch.IsEmpty() {
+				k.setLastAttestedNonce(ctx, types.ClaimTypeEthereumBridgeWithdrawalBatch, spec.lastObservedBatch)
+			}
+			// with all the orchestrator's signatures stored
+			for ethAddr, valAddr := range spec.srcSigners {
+				k.SetEthAddress(ctx, valAddr, ethAddr)
+				if sig, ok := sigs[valAddr.String()]; ok {
+					k.SetBridgeApprovalSignature(ctx, types.ClaimTypeOrchestratorSignedWithdrawBatch, nonce, valAddr, sig)
+				}
+			}
+
+			// when
+			bz, err := queryInflightBatches(ctx, k)
+
+			// then
+			require.NoError(t, err)
+			if spec.expResp == nil {
+				require.Nil(t, bz)
+				return
+			}
+			require.NotNil(t, bz)
+
+			var got []ApprovedOutgoingTxBatchResponse
+			k.cdc.MustUnmarshalJSON(bz, &got)
+
+			assert.Equal(t, spec.expResp, got)
+		})
+	}
+}
+
 func createEthAddress(i int) types.EthereumAddress {
 	return types.EthereumAddress(gethCommon.BytesToAddress(bytes.Repeat([]byte{byte(i)}, 20)))
+}
 
+func createFakeEthSignature(n int) []byte {
+	return bytes.Repeat([]byte{byte(n)}, 64)
+}
+
+func createValAddress() sdk.ValAddress {
+	return sdk.ValAddress(secp256k1.GenPrivKey().PubKey().Address())
 }

--- a/module/x/peggy/types/attestation.go
+++ b/module/x/peggy/types/attestation.go
@@ -316,9 +316,9 @@ type BridgeBootstrap struct {
 	StartThreshold   uint64           `json:"start_threshold,omitempty" yaml:"start_threshold"`
 }
 
-func NewBridgeBootstrap(peggyID []byte, bridgeValidators BridgeValidators, startThreshold uint64) *BridgeBootstrap {
+func NewBridgeBootstrap(peggyID []byte, bridgeValidators BridgeValidators, startThreshold uint64) BridgeBootstrap {
 	bridgeValidators.Sort()
-	return &BridgeBootstrap{PeggyID: peggyID, BridgeValidators: bridgeValidators, StartThreshold: startThreshold}
+	return BridgeBootstrap{PeggyID: peggyID, BridgeValidators: bridgeValidators, StartThreshold: startThreshold}
 }
 
 func (b BridgeBootstrap) Hash() []byte {

--- a/module/x/peggy/types/key.go
+++ b/module/x/peggy/types/key.go
@@ -108,12 +108,11 @@ func GetBridgeApprovalSignatureKeyPrefix(claimType ClaimType) []byte {
 func GetBridgeApprovalSignatureKey(claimType ClaimType, nonce UInt64Nonce, validator sdk.ValAddress) []byte {
 	prefix := GetBridgeApprovalSignatureKeyPrefix(claimType)
 	prefixLen := len(prefix)
-	nonceLen := 8
 
-	r := make([]byte, prefixLen+nonceLen+len(validator))
+	r := make([]byte, prefixLen+UInt64NonceByteLen+len(validator))
 	copy(r, prefix)
 	copy(r[prefixLen:], nonce.Bytes())
-	copy(r[prefixLen+nonceLen:], validator)
+	copy(r[prefixLen+UInt64NonceByteLen:], validator)
 	return r
 }
 

--- a/module/x/peggy/types/nonce.go
+++ b/module/x/peggy/types/nonce.go
@@ -22,6 +22,8 @@ type nonce interface {
 	IsEmpty() bool
 }
 
+const UInt64NonceByteLen = 8
+
 type UInt64Nonce uint64
 
 var _ nonce = NewUInt64Nonce(0)


### PR DESCRIPTION
After #66 

Return signatures sorted by validator power.
Bridge validators and signatures with `0` power or without Ethereum address are pruned.