### PR TITLE
Ethereum to cosmos

### DIFF
--- a/module/x/peggy/keeper/attestation.go
+++ b/module/x/peggy/keeper/attestation.go
@@ -28,6 +28,10 @@ func (k Keeper) AddClaim(ctx sdk.Context, claimType types.ClaimType, nonce types
 	if err != nil {
 		return nil, err
 	}
+
+	// this is a really strange conditional that needs to be simplified, just asking for trouble.
+	// it is correct, but it's too difficult to read and there's too many ways for it to be true
+	// or false that are non-obvious. Great way to have a double-spend bug TODO refactor
 	if att.Certainty != types.CertaintyObserved || att.Status != types.ProcessStatusInit {
 		k.storeAttestation(ctx, att)
 		return att, nil

--- a/module/x/peggy/keeper/attestation.go
+++ b/module/x/peggy/keeper/attestation.go
@@ -29,6 +29,7 @@ func (k Keeper) AddClaim(ctx sdk.Context, claimType types.ClaimType, nonce types
 		return nil, err
 	}
 	if att.Certainty != types.CertaintyObserved || att.Status != types.ProcessStatusInit {
+		k.storeAttestation(ctx, att)
 		return att, nil
 	}
 

--- a/module/x/peggy/keeper/attestation_handler.go
+++ b/module/x/peggy/keeper/attestation_handler.go
@@ -67,7 +67,7 @@ func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation) error
 		if !ok {
 			return sdkerrors.Wrapf(types.ErrInvalid, "unexpected type: %T", att.Details)
 		}
-		// quick hack:  we are sstoring the bootstrap data here to avoid the gov process in MVY.
+		// quick hack:  we are storing the bootstrap data here to avoid the gov process in MVY.
 		// TODO: improve process by:
 		// - verify StartThreshold == params.StartThreshold
 		// - verify PeggyID == params.PeggyID

--- a/module/x/peggy/types/attestation.go
+++ b/module/x/peggy/types/attestation.go
@@ -257,9 +257,6 @@ func (t AttestationTally) ThresholdsReached() bool {
 }
 
 func (a *Attestation) AddVote(now time.Time, power uint64) error {
-	if a.Status != ProcessStatusInit {
-		return sdkerrors.Wrapf(ErrInvalid, "%d", a.Status) // no status to string impl, yet
-	}
 	if now.After(a.ConfirmationEndTime) {
 		return ErrTimeout
 	}

--- a/module/x/peggy/types/msgs.go
+++ b/module/x/peggy/types/msgs.go
@@ -345,7 +345,7 @@ var NoUniqueClaimDetails AttestationDetails = nil
 // EthereumBridgeDepositClaim claims that a token was deposited on the bridge contract.
 type EthereumBridgeDepositClaim struct {
 	Nonce          UInt64Nonce     `json:"nonce" yaml:"nonce"`
-	ERC20Token     ERC20Token      `json:"erc_20_token"`
+	ERC20Token     ERC20Token      `json:"erc20_token"`
 	EthereumSender EthereumAddress `json:"ethereum_sender" yaml:"ethereum_sender"`
 	CosmosReceiver sdk.AccAddress  `json:"cosmos_receiver" yaml:"cosmos_receiver"`
 }
@@ -505,7 +505,7 @@ func (m MsgCreateEthereumClaims) ValidateBasic() error {
 	}
 	for i := range m.Claims {
 		if err := m.Claims[i].ValidateBasic(); err != nil {
-			return sdkerrors.Wrapf(err, "claim %d", i)
+			return sdkerrors.Wrapf(err, "claim %d failed ValidateBasic()", i)
 		}
 	}
 	return nil

--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -539,9 +539,9 @@ checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
 
 [[package]]
 name = "contact"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0b4e028eae0c2d21c2e24a9ba3be600123735dfba880969d39975fcac93c75"
+checksum = "e4ba519e239eb7b37fcf76bfd21e6b501969ff9a3b0f696a719cc753b905a3bc"
 dependencies = [
  "actix-web",
  "deep_space",

--- a/orchestrator/cosmos_peggy/src/messages.rs
+++ b/orchestrator/cosmos_peggy/src/messages.rs
@@ -90,20 +90,17 @@ pub struct ConfirmBatchMsg {
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct ERC20Token {
-    amount: Uint256,
-    symbol: String,
+    pub amount: Uint256,
+    pub symbol: String,
     #[serde(rename = "token_contract_address")]
-    token_contract_address: EthAddress,
+    pub token_contract_address: EthAddress,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct EthereumBridgeDepositClaim {
+    /// this was added on the cosmos side due to a poorly designed interface
+    /// will always be zero
     pub nonce: Uint256,
-    pub validator: Address,
-    /// a hex encoded string representing the Ethereum signature
-    #[serde(rename = "signature")]
-    pub eth_signature: String,
-    #[serde(rename = "ERC20Token")]
     pub erc20_token: ERC20Token,
     pub ethereum_sender: EthAddress,
     pub cosmos_receiver: Address,
@@ -131,22 +128,28 @@ pub struct EthereumBridgeBootstrappedClaim {
     peggy_id: String,
     /// the amount of voting power (measured by the bridge, not cosmos) required
     /// to start the bridge, remember bridge powers are normalized to u32 max so
-    /// this would be computed as some percentage of that with on bearing on what
+    /// this would be computed as some percentage of that with no bearing on what
     /// Cosmos would consider the power number to be.
     start_threshold: Uint256,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash)]
+#[serde(tag = "type", content = "value")]
 pub enum EthereumBridgeClaim {
+    #[serde(rename = "peggy/EthereumBridgeDepositClaim")]
     EthereumBridgeDepositClaim(EthereumBridgeDepositClaim),
+    #[serde(rename = "peggy/EthereumBridgeMultiSigUpdateClaim")]
     EthereumBridgeMultiSigUpdateClaim(EthereumBridgeMultiSigUpdateClaim),
+    #[serde(rename = "peggy/EthereumBridgeWithdrawBatchClaim")]
     EthereumBridgeWithdrawBatchClaim(EthereumBridgeWithdrawBatchClaim),
+    #[serde(rename = "peggy/EthereumBridgeBootstrappedClaim")]
+    EthereumBridgeBootstrappedClaim(EthereumBridgeBootstrappedClaim),
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct CreateEthereumClaimsMsg {
     pub ethereum_chain_id: Uint256,
     pub bridge_contract_address: EthAddress,
-    pub validator: Address,
+    pub orchestrator: Address,
     pub claims: Vec<EthereumBridgeClaim>,
 }

--- a/orchestrator/ethereum_peggy/src/valset_update.rs
+++ b/orchestrator/ethereum_peggy/src/valset_update.rs
@@ -28,6 +28,7 @@ pub async fn send_eth_valset_update(
     let (new_addresses, new_powers) = new_valset.filter_empty_addresses()?;
     let old_nonce = old_valset.nonce;
     let new_nonce = new_valset.nonce;
+    assert!(new_nonce > old_nonce);
     let eth_address = our_eth_key.to_public_key().unwrap();
     info!(
         "Ordering signatures and submitting validator set {} -> {} update to Ethereum",
@@ -54,20 +55,25 @@ pub async fn send_eth_valset_update(
     let payload = clarity::abi::encode_call("updateValset(address[],uint256[],uint256,address[],uint256[],uint256,uint8[],bytes32[],bytes32[])",
     &[new_addresses.into(), new_powers.into(), new_nonce.into(), old_addresses.into(), old_powers.into(), old_nonce.into(), sig_arrays.v, sig_arrays.r, sig_arrays.s]).unwrap();
 
-    let tx = future_timeout(
-        timeout,
-        web3.send_transaction(
+    let before_nonce = get_valset_nonce(peggy_contract_address, eth_address, web3).await?;
+    if before_nonce != old_nonce.into() {
+        info!(
+            "Someone else updated the valset to {}, exiting early",
+            before_nonce
+        );
+        return Ok(());
+    }
+
+    let tx = web3
+        .send_transaction(
             peggy_contract_address,
             payload,
             0u32.into(),
             eth_address,
             our_eth_key,
             vec![SendTxOption::GasLimit(1_000_000u32.into())],
-        ),
-    )
-    .await
-    .expect("Valset update timed out")
-    .expect("Valset update failed for other reasons");
+        )
+        .await?;
     info!("Finished valset update with txid {:#066x}", tx);
 
     // TODO this segment of code works around the race condition for submitting valsets mostly

--- a/orchestrator/orchestrator/Cargo.toml
+++ b/orchestrator/orchestrator/Cargo.toml
@@ -21,7 +21,7 @@ cosmos_peggy = {path = "../cosmos_peggy"}
 peggy_utils = {path = "../peggy_utils"}
 
 deep_space = "0.2"
-contact = "0.1"
+contact = "0.1.8"
 serde_derive = "1.0"
 clarity = "0.4"
 docopt = "1"

--- a/orchestrator/orchestrator/src/ethereum_event_watcher.rs
+++ b/orchestrator/orchestrator/src/ethereum_event_watcher.rs
@@ -65,7 +65,6 @@ pub async fn check_for_events(
         let valsets = ValsetUpdatedEvent::from_logs(&valsets)?;
         let batches = TransactionBatchExecutedEvent::from_logs(&batches)?;
         let deposits = SendToCosmosEvent::from_logs(&deposits)?;
-        info!("Parsed stuff!");
         if !deposits.is_empty() {
             info!(
                 "Got deposit with sender {} and destination {} and amount {}",

--- a/orchestrator/orchestrator/src/ethereum_event_watcher.rs
+++ b/orchestrator/orchestrator/src/ethereum_event_watcher.rs
@@ -67,7 +67,7 @@ pub async fn check_for_events(
         let deposits = SendToCosmosEvent::from_logs(&deposits)?;
         if !deposits.is_empty() {
             info!(
-                "Got deposit with sender {} and destination {} and amount {}",
+                "Oracle observed deposit with sender {} and destination {} and amount {}",
                 deposits[0].sender, deposits[0].destination, deposits[0].amount
             )
         }

--- a/orchestrator/orchestrator/src/ethereum_event_watcher.rs
+++ b/orchestrator/orchestrator/src/ethereum_event_watcher.rs
@@ -84,7 +84,7 @@ pub async fn check_for_events(
                 fee,
             )
             .await?;
-            info!("Sent in Oracle claims response: {:?}", res);
+            trace!("Sent in Oracle claims response: {:?}", res);
         }
 
         Ok(latest_block)
@@ -103,18 +103,18 @@ fn to_bridge_claims(
     deposits: &[SendToCosmosEvent],
 ) -> Vec<EthereumBridgeClaim> {
     let mut out = Vec::new();
-    // for valset in valsets {
-    //     let nonce = valset.nonce.clone();
-    //     out.push(EthereumBridgeClaim::EthereumBridgeMultiSigUpdateClaim(
-    //         EthereumBridgeMultiSigUpdateClaim { nonce },
-    //     ));
-    // }
-    // for batch in batches {
-    //     let nonce = batch.nonce.clone();
-    //     out.push(EthereumBridgeClaim::EthereumBridgeWithdrawBatchClaim(
-    //         EthereumBridgeWithdrawBatchClaim { nonce },
-    //     ))
-    // }
+    for valset in valsets {
+        let nonce = valset.nonce.clone();
+        out.push(EthereumBridgeClaim::EthereumBridgeMultiSigUpdateClaim(
+            EthereumBridgeMultiSigUpdateClaim { nonce },
+        ));
+    }
+    for batch in batches {
+        let nonce = batch.nonce.clone();
+        out.push(EthereumBridgeClaim::EthereumBridgeWithdrawBatchClaim(
+            EthereumBridgeWithdrawBatchClaim { nonce },
+        ))
+    }
     for deposit in deposits {
         out.push(EthereumBridgeClaim::EthereumBridgeDepositClaim(
             EthereumBridgeDepositClaim {

--- a/orchestrator/orchestrator/src/main.rs
+++ b/orchestrator/orchestrator/src/main.rs
@@ -22,6 +22,7 @@ mod tests;
 mod valset_relaying;
 
 use crate::main_loop::orchestrator_main_loop;
+use crate::main_loop::LOOP_SPEED;
 use clarity::Address as EthAddress;
 use clarity::PrivateKey as EthPrivateKey;
 use contact::client::Contact;
@@ -63,8 +64,6 @@ lazy_static! {
     );
 }
 
-const LOOP_SPEED: Duration = Duration::from_secs(5);
-
 #[actix_rt::main]
 async fn main() {
     let args: Args = Docopt::new(USAGE.as_str())
@@ -96,7 +95,6 @@ async fn main() {
         contact,
         contract_address,
         fee_denom,
-        LOOP_SPEED,
     )
     .await;
 }

--- a/orchestrator/orchestrator/src/main_loop.rs
+++ b/orchestrator/orchestrator/src/main_loop.rs
@@ -34,9 +34,10 @@ pub async fn orchestrator_main_loop(
 
         let latest_eth_block = web3.eth_block_number().await.unwrap();
         let latest_cosmos_block = contact.get_latest_block_number().await.unwrap();
-        info!(
+        trace!(
             "Latest Eth block {} Latest Cosmos block {}",
-            latest_eth_block, latest_cosmos_block
+            latest_eth_block,
+            latest_cosmos_block
         );
 
         //  Checks for new valsets to sign and relays validator sets from Cosmos -> Ethereum including

--- a/orchestrator/orchestrator/src/test_runner.rs
+++ b/orchestrator/orchestrator/src/test_runner.rs
@@ -214,7 +214,7 @@ async fn main() {
     // bootstrapping tests finish here and we move into operational tests
 
     // send 3 valset updates to make sure the process works back to back
-    for _ in 0u32..3 {
+    for _ in 0u32..2 {
         test_valset_update(
             &contact,
             &web30,
@@ -247,6 +247,9 @@ async fn test_valset_update(
     miner_address: EthAddress,
     fee: Coin,
 ) {
+    // if we don't do this the orchestrators may run ahead of us and we'll be stuck here after
+    // getting credit for two loops when we did one
+    delay_for(Duration::from_secs(10)).await;
     let starting_eth_valset_nonce = get_valset_nonce(peggy_address, miner_address, &web30)
         .await
         .expect("Failed to get starting eth valset");
@@ -266,7 +269,10 @@ async fn test_valset_update(
         current_eth_valset_nonce,
     );
     while starting_eth_valset_nonce == current_eth_valset_nonce {
-        info!("Validator set is not yet updated, waiting");
+        info!(
+            "Validator set is not yet updated to {}>, waiting",
+            starting_eth_valset_nonce
+        );
         current_eth_valset_nonce = get_valset_nonce(peggy_address, miner_address, &web30)
             .await
             .expect("Failed to get current eth valset");

--- a/orchestrator/orchestrator/src/test_runner.rs
+++ b/orchestrator/orchestrator/src/test_runner.rs
@@ -215,7 +215,7 @@ async fn main() {
     // bootstrapping tests finish here and we move into operational tests
 
     // send 3 valset updates to make sure the process works back to back
-    for _ in 0u32..1 {
+    for _ in 0u32..3 {
         test_valset_update(
             &contact,
             &web30,
@@ -249,6 +249,9 @@ async fn main() {
     info!("Send to Cosmos txid: {:#066x}", tx_id);
 
     delay_for(TIMEOUT).await;
+
+    let account_info = contact.get_account_info(dest).await.unwrap();
+    info!("Account balance of {} is {:?}", dest, account_info)
 }
 
 async fn test_valset_update(

--- a/orchestrator/orchestrator/src/valset_relaying.rs
+++ b/orchestrator/orchestrator/src/valset_relaying.rs
@@ -33,7 +33,6 @@ pub async fn relay_valsets(
     fee: Coin,
     timeout: Duration,
 ) {
-    info!("Starting valset relay");
     let our_cosmos_address = cosmos_key.to_public_key().unwrap().to_address();
     let our_ethereum_address = ethereum_key.to_public_key().unwrap();
 
@@ -77,7 +76,6 @@ pub async fn relay_valsets(
 
     let mut latest_confirmed = None;
     let mut latest_valset = None;
-    info!("Retrieving validator set signatures from the Cosmos chain");
     for set in latest_valsets.result {
         let confirms = get_all_valset_confirms(contact, set.nonce).await;
         if let Ok(confirms) = confirms {
@@ -97,10 +95,6 @@ pub async fn relay_valsets(
     }
     let latest_cosmos_confirmed = latest_confirmed.unwrap();
     let latest_cosmos_valset = latest_valset.unwrap();
-    info!(
-        "Latest valset is {} latest confirmed is {}",
-        latest_cosmos_valset.nonce, latest_cosmos_confirmed.result[0].nonce
-    );
 
     let latest_ethereum_valset = get_valset_nonce(contract_address, our_ethereum_address, web3)
         .await
@@ -126,7 +120,7 @@ pub async fn relay_valsets(
                 .result
         };
 
-        send_eth_valset_update(
+        let _res = send_eth_valset_update(
             latest_cosmos_valset,
             old_valset,
             &latest_cosmos_confirmed.result,
@@ -135,7 +129,6 @@ pub async fn relay_valsets(
             contract_address,
             ethereum_key,
         )
-        .await
-        .expect("Failed to update valset!");
+        .await;
     }
 }

--- a/orchestrator/orchestrator/src/valset_relaying.rs
+++ b/orchestrator/orchestrator/src/valset_relaying.rs
@@ -30,8 +30,7 @@ pub async fn relay_valsets(
     web3: &Web3,
     contact: &Contact,
     contract_address: EthAddress,
-    // the denom to pay fees in
-    pay_fees_in: String,
+    fee: Coin,
     timeout: Duration,
 ) {
     info!("Starting valset relay");
@@ -49,10 +48,7 @@ pub async fn relay_valsets(
         send_valset_confirm(
             contact,
             ethereum_key,
-            Coin {
-                denom: pay_fees_in.clone(),
-                amount: 1u32.into(),
-            },
+            fee,
             last_unsigned_valset.result,
             cosmos_key,
             String::from_utf8(peggy_id.clone()).expect("Invalid PeggyID"),

--- a/orchestrator/peggy_utils/src/types.rs
+++ b/orchestrator/peggy_utils/src/types.rs
@@ -313,7 +313,6 @@ pub struct SendToCosmosEvent {
 
 impl SendToCosmosEvent {
     pub fn from_log(input: &Log) -> Result<SendToCosmosEvent, OrchestratorError> {
-        println!("Parsing {:?}", input);
         let topics = (
             input.topics.get(1),
             input.topics.get(2),

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,8 @@ You can keep up with the latest development by watching our [public standups](ht
   - [ ] Audit
 - Orchestrator / Relayer
   - [x] Validator set update relaying
-  - [ ] Ethereum -> Cosmos Oracle
+  - [x] Ethereum -> Cosmos Oracle
+  - [x] Ethereum -> Cosmos Token issuing
   - [ ] Transaction batch relaying
   - [ ] Tendermint KMS support
   - [ ] Audit

--- a/tests/container-scripts/integration-tests.sh
+++ b/tests/container-scripts/integration-tests.sh
@@ -5,4 +5,4 @@ NODES=3 # Permanently set to 3 for now!
 QUERY_FLAGS="--home /validator1 --trace --node=http://7.7.7.1:26657 --chain-id=peggy-test -o=json"
 
 pushd /peggy/orchestrator
-RUST_BACKTRACE=full RUST_LOG=INFO PATH=$PATH:$HOME/.cargo/bin cargo run --bin test-runner
+RUST_BACKTRACE=full RUST_LOG=INFO PATH=$PATH:$HOME/.cargo/bin cargo run --release --bin test-runner


### PR DESCRIPTION
This pull request provides a working MVP of tokens going from Ethereum to Cosmos.

The actual token bridge is pretty complete in this direction as we have duplicate protection, validator voting, issuance and really everything except erc20 token hash collision handling that is required by our pre-stargate token denom length limit. 

I still need to clean up the tests and deal with some reliability edge cases around relaying events and specifically valsets in the tests.

