### PR TITLE
Remove signature attestation and tally logic

### DIFF
--- a/module/x/peggy/client/cli/attestation_tx.go
+++ b/module/x/peggy/client/cli/attestation_tx.go
@@ -297,7 +297,7 @@ func CmdValsetConfirm(storeKey string, cdc *codec.Codec) *cobra.Command {
 			// Make the message
 			msg := types.MsgBridgeSignatureSubmission{
 				Nonce:             valset.Nonce,
-				ClaimType:         types.ClaimTypeOrchestratorSignedMultiSigUpdate,
+				SignType:          types.SignTypeOrchestratorSignedMultiSigUpdate,
 				Orchestrator:      cosmosAddr,
 				EthereumSignature: signature,
 			}
@@ -364,7 +364,7 @@ func CmdOutgointTXBatchConfirm(storeKey string, cdc *codec.Codec) *cobra.Command
 			// Make the message
 			msg := types.MsgBridgeSignatureSubmission{
 				Nonce:             batch.Nonce,
-				ClaimType:         types.ClaimTypeOrchestratorSignedWithdrawBatch,
+				SignType:          types.SignTypeOrchestratorSignedWithdrawBatch,
 				Orchestrator:      cosmosAddr,
 				EthereumSignature: signature,
 			}

--- a/module/x/peggy/client/cli/query.go
+++ b/module/x/peggy/client/cli/query.go
@@ -64,7 +64,6 @@ func QueryApproved(storeKey string, cdc *codec.Codec) *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 	testingTxCmd.AddCommand(flags.PostCommands(
-		CmdGetLastApprovedNonceRequest(storeKey, cdc),
 		CmdGetLastApprovedNoncesRequest(storeKey, cdc),
 		CmdGetLastApprovedMultiSigUpdateRequest(storeKey, cdc),
 		CmdGetInflightBatchesRequest(storeKey, cdc),
@@ -335,7 +334,7 @@ func CmdGetAllOutgoingTXBatchRequest(storeKey string, cdc *codec.Codec) *cobra.C
 func CmdGetAllAttestationsRequest(storeKey string, cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "all-attestations [claim type]",
-		Short: fmt.Sprintf("Get all attestations by claim type descending order. Claim types: %s", types.ToClaimTypeNames(append(types.AllOracleClaimTypes, types.AllSignerApprovalClaimTypes...)...)),
+		Short: fmt.Sprintf("Get all attestations by claim type descending order. Claim types: %s", types.ToClaimTypeNames(types.AllOracleClaimTypes...)),
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
@@ -357,7 +356,7 @@ func CmdGetAllAttestationsRequest(storeKey string, cdc *codec.Codec) *cobra.Comm
 func CmdGetAttestationRequest(storeKey string, cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "attestation [claim type] [nonce]",
-		Short: fmt.Sprintf("Get attestation by claim type and nonce. Claim types: %s", types.ToClaimTypeNames(append(types.AllOracleClaimTypes, types.AllSignerApprovalClaimTypes...)...)),
+		Short: fmt.Sprintf("Get attestation by claim type and nonce. Claim types: %s", types.ToClaimTypeNames(types.AllOracleClaimTypes...)),
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
@@ -421,29 +420,6 @@ func CmdGetInflightBatchesRequest(storeKey string, cdc *codec.Codec) *cobra.Comm
 				return nil
 			}
 			var out []keeper.ApprovedOutgoingTxBatchResponse
-			cdc.MustUnmarshalJSON(res, &out)
-			return cliCtx.PrintOutput(out)
-		},
-	}
-}
-func CmdGetLastApprovedNonceRequest(storeKey string, cdc *codec.Codec) *cobra.Command {
-	return &cobra.Command{
-		Use:   "nonce [claim type]",
-		Short: fmt.Sprintf("Get the last nonce that was approved for a claim type of %s", types.ToClaimTypeNames(types.AllSignerApprovalClaimTypes...)),
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-
-			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/lastNonce/%s", storeKey, args[0]), nil)
-			if err != nil {
-				return err
-			}
-			if len(res) == 0 {
-				fmt.Println("Nothing found")
-				return nil
-			}
-
-			var out types.UInt64Nonce
 			cdc.MustUnmarshalJSON(res, &out)
 			return cliCtx.PrintOutput(out)
 		},

--- a/module/x/peggy/client/rest/rest.go
+++ b/module/x/peggy/client/rest/rest.go
@@ -12,6 +12,7 @@ const (
 	nonce                  = "nonce"
 	bech32ValidatorAddress = "bech32ValidatorAddress"
 	claimType              = "claimType"
+	signType               = "signType"
 )
 
 // RegisterRoutes - Central function to define routes that get registered by the main application
@@ -33,7 +34,7 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) 
 	r.HandleFunc(fmt.Sprintf("/%s/last_observed_valset", storeName), lastObservedValsetHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/last_approved_valset", storeName), lastApprovedValsetHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/attestation/{%s}/{%s}", storeName, claimType, nonce), queryAttestation(cliCtx, storeName)).Methods("GET")
-	r.HandleFunc(fmt.Sprintf("/%s/sign_bridge_request/{%s}/{%s}", storeName, claimType, nonce), BridgeApprovalSignatureHandler(cliCtx)).Methods("POST")
+	r.HandleFunc(fmt.Sprintf("/%s/sign_bridge_request/{%s}/{%s}", storeName, signType, nonce), BridgeApprovalSignatureHandler(cliCtx)).Methods("POST")
 	r.HandleFunc(fmt.Sprintf("/%s/bootstrap", storeName), bootstrapConfirmHandler(cliCtx)).Methods("POST")
 
 }

--- a/module/x/peggy/client/rest/tx.go
+++ b/module/x/peggy/client/rest/tx.go
@@ -231,9 +231,9 @@ func BridgeApprovalSignatureHandler(cliCtx context.CLIContext) http.HandlerFunc 
 			return
 		}
 		vars := mux.Vars(r)
-		claimType, exists := types.ClaimTypeFromName(vars[claimType])
+		signType, exists := types.SignTypeFromName(vars[claimType])
 		if !exists {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, "unknown claim type")
+			rest.WriteErrorResponse(w, http.StatusBadRequest, "unknown sign type")
 			return
 		}
 		nonce, err := types.UInt64NonceFromString(vars[nonce])
@@ -249,7 +249,7 @@ func BridgeApprovalSignatureHandler(cliCtx context.CLIContext) http.HandlerFunc 
 
 		msg := types.MsgBridgeSignatureSubmission{
 			Nonce:             nonce,
-			ClaimType:         claimType,
+			SignType:          signType,
 			Orchestrator:      req.Orchestrator,
 			EthereumSignature: req.EthereumSignature,
 		}

--- a/module/x/peggy/handler_test.go
+++ b/module/x/peggy/handler_test.go
@@ -110,7 +110,7 @@ func TestHandleBridgeSignatureSubmission(t *testing.T) {
 				validSig, err := types.NewEthereumSignature(v.GetCheckpoint(), privKey)
 				require.NoError(t, err)
 				return MsgBridgeSignatureSubmission{
-					ClaimType:         types.ClaimTypeOrchestratorSignedMultiSigUpdate,
+					SignType:          types.SignTypeOrchestratorSignedMultiSigUpdate,
 					Nonce:             v.Nonce,
 					Orchestrator:      myOrchestratorAddr,
 					EthereumSignature: validSig,
@@ -139,7 +139,7 @@ func TestHandleBridgeSignatureSubmission(t *testing.T) {
 				validSig, err := types.NewEthereumSignature(checkpoint, privKey)
 				require.NoError(t, err)
 				return MsgBridgeSignatureSubmission{
-					ClaimType:         types.ClaimTypeOrchestratorSignedWithdrawBatch,
+					SignType:          types.SignTypeOrchestratorSignedWithdrawBatch,
 					Nonce:             b.Nonce,
 					Orchestrator:      myOrchestratorAddr,
 					EthereumSignature: validSig,
@@ -164,21 +164,9 @@ func TestHandleBridgeSignatureSubmission(t *testing.T) {
 			}
 			// then
 			require.NoError(t, err)
-
-			// and claim persisted
-			checkPoint, err := getCheckpoint(ctx, k, msg.ClaimType, msg.Nonce)
-			require.NoError(t, err)
-			claimFound := k.HasClaim(ctx, msg.ClaimType, msg.Nonce, myValAddr, types.SignedCheckpoint{
-				Checkpoint: checkPoint,
-			})
-			assert.True(t, claimFound)
 			// and approval persisted
-			sigFound := k.HasBridgeApprovalSignature(ctx, msg.ClaimType, msg.Nonce, myValAddr)
+			sigFound := k.HasBridgeApprovalSignature(ctx, msg.SignType, msg.Nonce, myValAddr)
 			assert.True(t, sigFound)
-
-			// and attestation persisted
-			a := k.GetAttestation(ctx, msg.ClaimType, msg.Nonce)
-			require.NotNil(t, a)
 		})
 	}
 }

--- a/module/x/peggy/keeper/attestation.go
+++ b/module/x/peggy/keeper/attestation.go
@@ -191,3 +191,31 @@ func (k Keeper) GetLastAttestedNonce(ctx sdk.Context, claimType types.ClaimType)
 	v := types.UInt64NonceFromBytes(iter.Key())
 	return &v
 }
+
+func (k Keeper) SetBridgeObservedSignature(ctx sdk.Context, claimType types.ClaimType, nonce types.UInt64Nonce, validator sdk.ValAddress, signature []byte) {
+	store := ctx.KVStore(k.storeKey)
+	store.Set(types.GetBridgeObservedSignatureKey(claimType, nonce, validator), signature)
+}
+
+func (k Keeper) GetBridgeObservedSignature(ctx sdk.Context, claimType types.ClaimType, nonce types.UInt64Nonce, validator sdk.ValAddress) []byte {
+	store := ctx.KVStore(k.storeKey)
+	return store.Get(types.GetBridgeObservedSignatureKey(claimType, nonce, validator))
+}
+
+func (k Keeper) HasBridgeObservedSignature(ctx sdk.Context, claimType types.ClaimType, nonce types.UInt64Nonce, validator sdk.ValAddress) bool {
+	store := ctx.KVStore(k.storeKey)
+	return store.Has(types.GetBridgeObservedSignatureKey(claimType, nonce, validator))
+}
+
+func (k Keeper) IterateBridgeObservedSignatures(ctx sdk.Context, claimType types.ClaimType, nonce types.UInt64Nonce, cb func(_ []byte, sig []byte) bool) {
+	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), types.GetBridgeObservedSignatureKeyPrefix(claimType))
+	iter := prefixStore.Iterator(prefixRange(nonce.Bytes()))
+	defer iter.Close()
+
+	for ; iter.Valid(); iter.Next() {
+		// cb returns true to stop early
+		if cb(iter.Key(), iter.Value()) {
+			break
+		}
+	}
+}

--- a/module/x/peggy/keeper/attestation_handler.go
+++ b/module/x/peggy/keeper/attestation_handler.go
@@ -81,22 +81,6 @@ func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation) error
 		// the peggy bridge can not operate proper without orchestrators having their ethereum
 		// addresses set before.
 		return a.keeper.SetBootstrapValset(ctx, initialMultisigSet)
-	case types.ClaimTypeOrchestratorSignedMultiSigUpdate:
-		signedCheckpoint, ok := att.Details.(types.SignedCheckpoint)
-		if !ok {
-			return sdkerrors.Wrapf(types.ErrInvalid, "unexpected type: %T", att.Details)
-		}
-		_ = signedCheckpoint
-		// todo: any cleanup to do? delete all valsets with nonce < last observed one?
-		return nil
-	case types.ClaimTypeOrchestratorSignedWithdrawBatch:
-		signedCheckpoint, ok := att.Details.(types.SignedCheckpoint)
-		if !ok {
-			return sdkerrors.Wrapf(types.ErrInvalid, "unexpected type: %T", att.Details)
-		}
-		_ = signedCheckpoint
-		// todo: any cleanup to do? delete all withdraw batches with nonce < last observed one?
-		return nil
 	default:
 		return sdkerrors.Wrapf(types.ErrInvalid, "event type: %s", att.ClaimType)
 	}

--- a/module/x/peggy/keeper/keeper.go
+++ b/module/x/peggy/keeper/keeper.go
@@ -122,29 +122,25 @@ func (k Keeper) IterateValsetRequest(ctx sdk.Context, cb func(key []byte, val ty
 	}
 }
 
-// deprecated use SetBridgeApprovalSignature instead
-func (k Keeper) SetValsetConfirm(ctx sdk.Context, valsetConf types.MsgValsetConfirm) {
+func (k Keeper) SetBridgeApprovalSignature(ctx sdk.Context, signType types.SignType, nonce types.UInt64Nonce, validator sdk.ValAddress, signature []byte) []byte {
 	store := ctx.KVStore(k.storeKey)
-	store.Set(types.GetValsetConfirmKey(valsetConf.Nonce, valsetConf.Validator), k.cdc.MustMarshalBinaryBare(valsetConf))
+	key := types.GetBridgeApprovalSignatureKey(signType, nonce, validator)
+	store.Set(key, signature)
+	return key
 }
 
-func (k Keeper) SetBridgeApprovalSignature(ctx sdk.Context, claimType types.ClaimType, nonce types.UInt64Nonce, validator sdk.ValAddress, signature []byte) {
+func (k Keeper) GetBridgeApprovalSignature(ctx sdk.Context, signType types.SignType, nonce types.UInt64Nonce, validator sdk.ValAddress) []byte {
 	store := ctx.KVStore(k.storeKey)
-	store.Set(types.GetBridgeApprovalSignatureKey(claimType, nonce, validator), signature)
+	return store.Get(types.GetBridgeApprovalSignatureKey(signType, nonce, validator))
 }
 
-func (k Keeper) GetBridgeApprovalSignature(ctx sdk.Context, claimType types.ClaimType, nonce types.UInt64Nonce, validator sdk.ValAddress) []byte {
+func (k Keeper) HasBridgeApprovalSignature(ctx sdk.Context, signType types.SignType, nonce types.UInt64Nonce, validator sdk.ValAddress) bool {
 	store := ctx.KVStore(k.storeKey)
-	return store.Get(types.GetBridgeApprovalSignatureKey(claimType, nonce, validator))
+	return store.Has(types.GetBridgeApprovalSignatureKey(signType, nonce, validator))
 }
 
-func (k Keeper) HasBridgeApprovalSignature(ctx sdk.Context, claimType types.ClaimType, nonce types.UInt64Nonce, validator sdk.ValAddress) bool {
-	store := ctx.KVStore(k.storeKey)
-	return store.Has(types.GetBridgeApprovalSignatureKey(claimType, nonce, validator))
-}
-
-func (k Keeper) IterateBridgeApprovalSignatures(ctx sdk.Context, claimType types.ClaimType, nonce types.UInt64Nonce, cb func(_ []byte, sig []byte) bool) {
-	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), types.GetBridgeApprovalSignatureKeyPrefix(claimType))
+func (k Keeper) IterateBridgeApprovalSignatures(ctx sdk.Context, signType types.SignType, nonce types.UInt64Nonce, cb func(_ []byte, sig []byte) bool) {
+	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), types.GetBridgeApprovalSignatureKeyPrefix(signType))
 	iter := prefixStore.Iterator(prefixRange(nonce.Bytes()))
 	defer iter.Close()
 
@@ -166,6 +162,12 @@ func (k Keeper) GetValsetConfirm(ctx sdk.Context, nonce types.UInt64Nonce, valid
 	confirm := types.MsgValsetConfirm{}
 	k.cdc.MustUnmarshalBinaryBare(entity, &confirm)
 	return &confirm
+}
+
+// deprecated use SetBridgeObservedSignature instead
+func (k Keeper) SetValsetConfirm(ctx sdk.Context, valsetConf types.MsgValsetConfirm) {
+	store := ctx.KVStore(k.storeKey)
+	store.Set(types.GetValsetConfirmKey(valsetConf.Nonce, valsetConf.Validator), k.cdc.MustMarshalBinaryBare(valsetConf))
 }
 
 // Iterate through all valset confirms for a nonce in ASC order

--- a/module/x/peggy/keeper/querier.go
+++ b/module/x/peggy/keeper/querier.go
@@ -52,14 +52,10 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 			return lastProcessedNonce(ctx, path[1], keeper)
 		case QueryLastObservedNonces:
 			return lastObservedNonces(ctx, keeper)
-		case QueryLastApprovedNonces:
-			return lastApprovedNonces(ctx, keeper)
 		case QueryLastPendingBatchRequestByAddr:
 			return lastPendingBatchRequest(ctx, path[1], keeper)
 		case QueryOutgoingTxBatches:
 			return allBatchesRequest(ctx, keeper)
-		case QueryLastApprovedValset:
-			return lastApprovedMultiSigUpdate(ctx, keeper)
 		case QueryLastObservedValset:
 			return lastObservedMultiSigUpdate(ctx, keeper)
 		case QueryAttestationsByClaimType:
@@ -186,7 +182,7 @@ func lastPendingValsetRequest(ctx sdk.Context, operatorAddr string, keeper Keepe
 
 	var pendingValsetReq *types.Valset
 	keeper.IterateValsetRequest(ctx, func(_ []byte, val types.Valset) bool {
-		found := keeper.HasBridgeApprovalSignature(ctx, types.ClaimTypeOrchestratorSignedMultiSigUpdate, val.Nonce, validatorAddr)
+		found := keeper.HasBridgeApprovalSignature(ctx, types.SignTypeOrchestratorSignedMultiSigUpdate, val.Nonce, validatorAddr)
 		if !found {
 			pendingValsetReq = &val
 		}
@@ -238,33 +234,9 @@ func lastObservedNonces(ctx sdk.Context, keeper Keeper) ([]byte, error) {
 	return sdk.SortJSON(res)
 }
 
-// lastApprovedNonces returns a list of nonces. One for each claim type if exists
-func lastApprovedNonces(ctx sdk.Context, keeper Keeper) ([]byte, error) {
-	result := make(map[string]types.UInt64Nonce, len(types.AllOracleClaimTypes))
-	for _, v := range types.AllSignerApprovalClaimTypes {
-		nonce := keeper.GetLastAttestedNonce(ctx, v)
-		if nonce != nil {
-			result[v.String()] = *nonce
-		}
-	}
-	if len(result) == 0 {
-		return nil, nil
-	}
-	res, err := codec.MarshalJSONIndent(keeper.cdc, result)
-	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
-	}
-	return sdk.SortJSON(res)
-}
-
 type MultiSigUpdateResponse struct {
 	Valset     types.Valset `json:"valset"`
 	Signatures [][]byte     `json:"signatures,omitempty"`
-}
-
-func lastApprovedMultiSigUpdate(ctx sdk.Context, keeper Keeper) ([]byte, error) {
-	nonce := keeper.GetLastAttestedNonce(ctx, types.ClaimTypeOrchestratorSignedMultiSigUpdate)
-	return fetchMultiSigUpdateData(ctx, nonce, keeper)
 }
 
 func lastObservedMultiSigUpdate(ctx sdk.Context, keeper Keeper) ([]byte, error) {
@@ -290,7 +262,7 @@ func fetchMultiSigUpdateData(ctx sdk.Context, nonce *types.UInt64Nonce, keeper K
 	}
 
 	addToSig := make(map[types.EthereumAddress][]byte, len(result.Valset.Members))
-	keeper.IterateBridgeApprovalSignatures(ctx, types.ClaimTypeOrchestratorSignedMultiSigUpdate, *nonce, func(key []byte, sig []byte) bool {
+	keeper.IterateBridgeApprovalSignatures(ctx, types.SignTypeOrchestratorSignedMultiSigUpdate, *nonce, func(key []byte, sig []byte) bool {
 		var valAddr sdk.ValAddress = key[types.UInt64NonceByteLen:] // key = nonce + validator address
 		ethAddr := keeper.GetEthAddress(ctx, valAddr)
 		if ethAddr == nil || ethAddr.IsEmpty() {
@@ -328,7 +300,7 @@ func lastPendingBatchRequest(ctx sdk.Context, operatorAddr string, keeper Keeper
 
 	var pendingBatchReq *types.OutgoingTxBatch
 	keeper.IterateOutgoingTXBatches(ctx, func(_ []byte, batch types.OutgoingTxBatch) bool {
-		found := keeper.HasBridgeApprovalSignature(ctx, types.ClaimTypeOrchestratorSignedWithdrawBatch, batch.Nonce, validatorAddr)
+		found := keeper.HasBridgeApprovalSignature(ctx, types.SignTypeOrchestratorSignedWithdrawBatch, batch.Nonce, validatorAddr)
 		if !found {
 			pendingBatchReq = &batch
 		}
@@ -380,7 +352,7 @@ func queryInflightBatches(ctx sdk.Context, keeper Keeper) ([]byte, error) {
 		}
 
 		addToSig := make(map[types.EthereumAddress][]byte)
-		keeper.IterateBridgeApprovalSignatures(ctx, types.ClaimTypeOrchestratorSignedWithdrawBatch, batches[i].Nonce, func(key []byte, sig []byte) bool {
+		keeper.IterateBridgeApprovalSignatures(ctx, types.SignTypeOrchestratorSignedWithdrawBatch, batches[i].Nonce, func(key []byte, sig []byte) bool {
 			var valAddr sdk.ValAddress = key[types.UInt64NonceByteLen:] // key = nonce + validator address
 			ethAddr := keeper.GetEthAddress(ctx, valAddr)
 			if ethAddr == nil || ethAddr.IsEmpty() {

--- a/module/x/peggy/types/attestation.go
+++ b/module/x/peggy/types/attestation.go
@@ -140,29 +140,20 @@ const (
 	ClaimTypeEthereumBridgeWithdrawalBatch ClaimType = 2
 	ClaimTypeEthereumBridgeMultiSigUpdate  ClaimType = 3
 	ClaimTypeEthereumBridgeBootstrap       ClaimType = 4
-
-	// signed confirmations on cosmos for Ethereum side
-	ClaimTypeOrchestratorSignedMultiSigUpdate ClaimType = 5
-	ClaimTypeOrchestratorSignedWithdrawBatch  ClaimType = 6
 )
 
 var claimTypeToNames = map[ClaimType]string{
-	ClaimTypeEthereumBridgeDeposit:            "bridge_deposit",
-	ClaimTypeEthereumBridgeWithdrawalBatch:    "bridge_withdrawal_batch",
-	ClaimTypeEthereumBridgeMultiSigUpdate:     "bridge_multisig_update",
-	ClaimTypeEthereumBridgeBootstrap:          "bridge_bootstrap",
-	ClaimTypeOrchestratorSignedMultiSigUpdate: "orchestrator_signed_multisig_update",
-	ClaimTypeOrchestratorSignedWithdrawBatch:  "orchestrator_signed_withdraw_batch",
+	ClaimTypeEthereumBridgeDeposit:         "bridge_deposit",
+	ClaimTypeEthereumBridgeWithdrawalBatch: "bridge_withdrawal_batch",
+	ClaimTypeEthereumBridgeMultiSigUpdate:  "bridge_multisig_update",
+	ClaimTypeEthereumBridgeBootstrap:       "bridge_bootstrap",
 }
 
 // AllOracleClaimTypes types that are observed and submitted by the current orchestrator set
 var AllOracleClaimTypes = []ClaimType{ClaimTypeEthereumBridgeDeposit, ClaimTypeEthereumBridgeWithdrawalBatch, ClaimTypeEthereumBridgeMultiSigUpdate, ClaimTypeEthereumBridgeBootstrap}
 
-// AllSignerApprovalClaimTypes types that are signed with by the bridge multisig set
-var AllSignerApprovalClaimTypes = []ClaimType{ClaimTypeOrchestratorSignedMultiSigUpdate, ClaimTypeOrchestratorSignedWithdrawBatch}
-
 func ClaimTypeFromName(s string) (ClaimType, bool) {
-	for _, v := range append(AllOracleClaimTypes, AllSignerApprovalClaimTypes...) {
+	for _, v := range AllOracleClaimTypes {
 		name, ok := claimTypeToNames[v]
 		if ok && name == s {
 			return v, true
@@ -176,24 +167,6 @@ func ToClaimTypeNames(s ...ClaimType) []string {
 		r[i] = s[i].String()
 	}
 	return r
-}
-
-func IsSignerApprovalClaimType(s ClaimType) bool {
-	for _, v := range AllSignerApprovalClaimTypes {
-		if v == s {
-			return true
-		}
-	}
-	return false
-}
-
-func IsOracleObservationClaimType(s ClaimType) bool {
-	for _, v := range AllOracleClaimTypes {
-		if v == s {
-			return true
-		}
-	}
-	return false
 }
 
 func (c ClaimType) String() string {

--- a/module/x/peggy/types/key.go
+++ b/module/x/peggy/types/key.go
@@ -36,6 +36,7 @@ var (
 	OutgoingTXBatchConfirmKey  = []byte{0xb}
 	BridgeApprovalSignatureKey = []byte{0xe}
 	SecondIndexNonceByClaimKey = []byte{0xf}
+	BridgeObservedSignatureKey = []byte{0x10}
 
 	// sequence keys
 	KeyLastTXPoolID        = append(SequenceKeyPrefix, []byte("lastTxPoolId")...)
@@ -102,11 +103,26 @@ func GetOutgoingTXBatchConfirmKey(nonce UInt64Nonce, validator sdk.ValAddress) [
 	return append(OutgoingTXBatchConfirmKey, append(nonce.Bytes(), validator.Bytes()...)...)
 }
 
-func GetBridgeApprovalSignatureKeyPrefix(claimType ClaimType) []byte {
-	return append(BridgeApprovalSignatureKey, claimType.Bytes()...)
+func GetBridgeApprovalSignatureKeyPrefix(s SignType) []byte {
+	return append(BridgeApprovalSignatureKey, s.Bytes()...)
 }
-func GetBridgeApprovalSignatureKey(claimType ClaimType, nonce UInt64Nonce, validator sdk.ValAddress) []byte {
-	prefix := GetBridgeApprovalSignatureKeyPrefix(claimType)
+func GetBridgeApprovalSignatureKey(singType SignType, nonce UInt64Nonce, validator sdk.ValAddress) []byte {
+	prefix := GetBridgeApprovalSignatureKeyPrefix(singType)
+	prefixLen := len(prefix)
+
+	r := make([]byte, prefixLen+UInt64NonceByteLen+len(validator))
+	copy(r, prefix)
+	copy(r[prefixLen:], nonce.Bytes())
+	copy(r[prefixLen+UInt64NonceByteLen:], validator)
+	return r
+}
+
+func GetBridgeObservedSignatureKeyPrefix(c ClaimType) []byte {
+	return append(BridgeApprovalSignatureKey, c.Bytes()...)
+}
+
+func GetBridgeObservedSignatureKey(claimType ClaimType, nonce UInt64Nonce, validator sdk.ValAddress) []byte {
+	prefix := GetBridgeObservedSignatureKeyPrefix(claimType)
 	prefixLen := len(prefix)
 
 	r := make([]byte, prefixLen+UInt64NonceByteLen+len(validator))

--- a/module/x/peggy/types/msgs.go
+++ b/module/x/peggy/types/msgs.go
@@ -523,7 +523,7 @@ func (m MsgCreateEthereumClaims) GetSigners() []sdk.AccAddress {
 // MsgBridgeSignatureSubmission submits the Ethereum signature for a given nonce an claim type.
 type MsgBridgeSignatureSubmission struct {
 	Nonce             UInt64Nonce    `json:"nonce"`
-	ClaimType         ClaimType      `json:"claim_type"`
+	SignType          SignType       `json:"sign_type"`
 	Orchestrator      sdk.AccAddress `json:"orchestrator"`
 	EthereumSignature []byte         `json:"ethereum_signature"`
 }
@@ -539,8 +539,8 @@ func (msg MsgBridgeSignatureSubmission) ValidateBasic() error {
 	if err := msg.Nonce.ValidateBasic(); err != nil {
 		return sdkerrors.Wrap(err, "nonce")
 	}
-	if !IsSignerApprovalClaimType(msg.ClaimType) {
-		return sdkerrors.Wrap(ErrInvalid, "claim type")
+	if !IsSignType(msg.SignType) {
+		return sdkerrors.Wrap(ErrInvalid, "sign type")
 	}
 	if msg.Orchestrator.Empty() {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.Orchestrator.String())


### PR DESCRIPTION
🚧  WIP - early version

Resolves #82 

With this patch the attestation and tally logic for Multisig set signatures is removed.

**This is an early version for fast feedback. Unit tests and manual tests are missing.**

* `ClaimType` and `SignType` are separated now. For the MVP the `ClaimType` was "abused" for multisig and batch signature submissions
* `SignType` signatures are stored under a new prefix key
* The cosmos side does not have any knowledge about the "last" >66% power signed valset or batch anymore

TBD: Breaking changes to the REST endpoint?


