### PR TITLE
Batch Freeing

### DIFF
--- a/module/x/peggy/keeper/attestation_handler.go
+++ b/module/x/peggy/keeper/attestation_handler.go
@@ -33,55 +33,35 @@ func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation) error
 		if err != nil {
 			return sdkerrors.Wrap(err, "transfer vouchers")
 		}
+
 	case types.ClaimTypeEthereumBridgeWithdrawalBatch:
-		b := a.keeper.GetOutgoingTXBatch(ctx, att.EventNonce) // TODO: this is not the correct nonce. We need the batch nonce.
+		details, ok := att.Details.(types.WithdrawalBatch)
+		if !ok {
+			return sdkerrors.Wrapf(types.ErrInvalid, "unexpected type: %T", att.Details)
+		}
+
+		b := a.keeper.GetOutgoingTXBatch(ctx, details.BatchNonce)
 		if b == nil {
 			return sdkerrors.Wrap(types.ErrUnknown, "nonce")
 		}
-		if err := b.Observed(); err != nil {
-			return err
-		}
-		a.keeper.storeBatch(ctx, *b)
+
 		// cleanup outgoing TX pool
 		for i := range b.Elements {
 			a.keeper.removePoolEntry(ctx, b.Elements[i].ID)
 		}
-		// TODO: implement logic to free transactions from all earlier batches as well.
+
+		// Iterate through remaining batches
+		a.keeper.IterateOutgoingTXBatches(ctx, func(key []byte, iter_batch types.OutgoingTxBatch) bool {
+			// If the iterated batches nonce is lower than the one that was just executed, cancel it
+			// TODO: iterate only over batches we need to iterate over
+			if iter_batch.Nonce < b.Nonce {
+				a.keeper.CancelOutgoingTXBatch(ctx, iter_batch.Nonce)
+			}
+			return false
+		})
+		a.keeper.deleteBatch(ctx, *b)
 		return nil
-	// case types.ClaimTypeEthereumBridgeMultiSigUpdate:
-	// 	if !a.keeper.HasValsetRequest(ctx, att.EventNonce) {
-	// 		return sdkerrors.Wrap(types.ErrUnknown, "nonce")
-	// 	}
 
-	// 	// todo: is there any cleanup for us like:
-	// 	a.keeper.IterateValsetRequest(ctx, func(key []byte, _ types.Valset) bool {
-	// 		nonce := types.UInt64NonceFromBytes(key)
-	// 		if att.Nonce.GreaterThan(nonce) {
-	// 			ctx.Logger().Info("TODO: let's remove valset request", "nonce", nonce)
-	// 		}
-	// 		// todo: also remove all confirmations < height
-	// 		return false
-	// 	})
-	// 	return nil
-	// case types.ClaimTypeEthereumBridgeBootstrap:
-	// 	bootstrap, ok := att.Details.(types.BridgeBootstrap)
-	// 	if !ok {
-	// 		return sdkerrors.Wrapf(types.ErrInvalid, "unexpected type: %T", att.Details)
-	// 	}
-	// 	// quick hack:  we are storing the bootstrap data here to avoid the gov process in MVY.
-	// 	// TODO: improve process by:
-	// 	// - verify StartThreshold == params.StartThreshold
-	// 	// - verify PeggyID == params.PeggyID
-
-	// 	a.keeper.setPeggyID(ctx, bootstrap.PeggyID)
-	// 	a.keeper.setStartThreshold(ctx, bootstrap.StartThreshold)
-
-	// 	initialMultisigSet := types.NewValset(att.EventNonce, bootstrap.BridgeValidators)
-
-	// 	// todo: do we want to do a sanity check that these validator addresses exits already?
-	// 	// the peggy bridge can not operate proper without orchestrators having their ethereum
-	// 	// addresses set before.
-	// 	return a.keeper.SetBootstrapValset(ctx, initialMultisigSet)
 	default:
 		return sdkerrors.Wrapf(types.ErrInvalid, "event type: %s", att.ClaimType)
 	}

--- a/module/x/peggy/types/attestation.go
+++ b/module/x/peggy/types/attestation.go
@@ -95,8 +95,8 @@ var (
 // WithdrawalBatch is an attestation detail that marks a batch of outgoing transactions executed and
 // frees earlier unexecuted batches
 type WithdrawalBatch struct {
-	BatchNonce sdk.Int    `json:"batch_nonce"`
-	ERC20Token ERC20Token `json:"erc_20_token"`
+	BatchNonce UInt64Nonce `json:"batch_nonce"`
+	ERC20Token ERC20Token  `json:"erc_20_token"`
 }
 
 func (b WithdrawalBatch) Hash() []byte {

--- a/module/x/peggy/types/batch.go
+++ b/module/x/peggy/types/batch.go
@@ -11,19 +11,19 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-type BatchStatus uint8
+// type BatchStatus uint8
 
-const (
-	BatchStatusUnknown   BatchStatus = 0
-	BatchStatusPending   BatchStatus = 1 // initial status
-	BatchStatusSubmitted BatchStatus = 2 // in flight to ETH
-	BatchStatusProcessed BatchStatus = 3 // observed - end state
-	BatchStatusCancelled BatchStatus = 4 // end state
-)
+// const (
+// 	BatchStatusUnknown BatchStatus = 0
+// 	BatchStatusPending BatchStatus = 1 // initial status
+// 	// BatchStatusSubmitted BatchStatus = 2 // in flight to ETH
+// 	BatchStatusProcessed BatchStatus = 3 // observed - end state
+// 	BatchStatusCancelled BatchStatus = 4 // end state
+// )
 
-func (b BatchStatus) String() string {
-	return []string{"unknown", "pending", "submitted", "observed", "processed", "cancelled"}[b]
-}
+// func (b BatchStatus) String() string {
+// 	return []string{"unknown", "pending", "submitted", "observed", "processed", "cancelled"}[b]
+// }
 
 type OutgoingTxBatch struct {
 	Nonce              UInt64Nonce          `json:"nonce"`
@@ -31,18 +31,17 @@ type OutgoingTxBatch struct {
 	CreatedAt          time.Time            `json:"created_at"`
 	TotalFee           ERC20Token           `json:"total_fee"`
 	BridgedDenominator BridgedDenominator   `json:"bridged_denominator"`
-	BatchStatus        BatchStatus          `json:"batch_status"`
 	Valset             Valset               `json:"valset"`
 	TokenContract      EthereumAddress      `json:"tokenContract"`
 }
 
-func (b *OutgoingTxBatch) Cancel() error {
-	if b.BatchStatus != BatchStatusPending {
-		return sdkerrors.Wrap(ErrInvalid, "status - batch not pending")
-	}
-	b.BatchStatus = BatchStatusCancelled
-	return nil
-}
+// func (b *OutgoingTxBatch) Cancel() error {
+// 	if b.BatchStatus != BatchStatusPending {
+// 		return sdkerrors.Wrap(ErrInvalid, "status - batch not pending")
+// 	}
+// 	b.BatchStatus = BatchStatusCancelled
+// 	return nil
+// }
 
 func (b OutgoingTxBatch) GetCheckpoint() ([]byte, error) {
 
@@ -210,13 +209,13 @@ func (b OutgoingTxBatch) GetCheckpoint() ([]byte, error) {
 	return batchDigest.Bytes(), nil
 }
 
-func (b *OutgoingTxBatch) Observed() error {
-	if b.BatchStatus != BatchStatusPending && b.BatchStatus != BatchStatusSubmitted {
-		return sdkerrors.Wrap(ErrInvalid, "status")
-	}
-	b.BatchStatus = BatchStatusProcessed
-	return nil
-}
+// func (b *OutgoingTxBatch) Observed() error {
+// 	if b.BatchStatus != BatchStatusPending && b.BatchStatus != BatchStatusSubmitted {
+// 		return sdkerrors.Wrap(ErrInvalid, "status")
+// 	}
+// 	b.BatchStatus = BatchStatusProcessed
+// 	return nil
+// }
 
 type OutgoingTransferTx struct {
 	ID          uint64          `json:"txid"`

--- a/module/x/peggy/types/batch_test.go
+++ b/module/x/peggy/types/batch_test.go
@@ -53,7 +53,6 @@ func TestOutgoingTxBatchCheckpointGold1(t *testing.T) {
 			Symbol:               "MAX",
 			CosmosVoucherDenom:   "peggy39b512461b",
 		},
-		BatchStatus:   1,
 		Valset:        v,
 		TokenContract: erc20Addr,
 	}


### PR DESCRIPTION
This is to track work on finishing the transaction batch functionality

- [x] Free transactions from earlier batches when a later batch is executed
- [x] Get batches using the batch nonce not the event nonce (note that we still need to separate these into nonces by denom)
- [x] Add tests for invalidating an earlier batch when a later batch is seen to have entered the Ethereum chain by the oracle.
