### PR TITLE
Instruct the user to wait for testnet start

### DIFF
--- a/tests/container-scripts/integration-tests.sh
+++ b/tests/container-scripts/integration-tests.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -eu
 
+FILE=/contracts
+if test -f "$FILE"; then
+echo "Contracts already deployed, running tests"
+else 
+echo "Testnet is not started yet, please wait before running tests"
+exit 0
+fi 
+
 set +e
 killall -9 test-runner
 set -e


### PR DESCRIPTION
In order to deploy the contracts only once per testnet run we added
some condtional compliation to the test runner binary and ran this
version of test-runner inside of start_chains.sh. This works quite
well but presents an issue when someone attempts to run the tests
before the chain has fully finished starting.

Sicne the tests use a different version of test-runner they try and
kill the previous instance before starting. If bootstrapping is still
in progress this means that they kill the test-runner instance in
start_chains.sh and prevent the test network from ever bootstrapping
successfully.

In order to resolve this we add a simple conditional to the integration
tests that checks for the output of the bootstrapping test-runner instance
and short circuts launching further test-runner instances until it has
completed.