### PR TITLE
Audit changes and take valsets out of batches (solidity changes only)

### DIFF
--- a/solidity/contracts/Peggy.sol
+++ b/solidity/contracts/Peggy.sol
@@ -84,7 +84,7 @@ contract Peggy {
 		uint8 _v,
 		bytes32 _r,
 		bytes32 _s
-	) public pure returns (bool) {
+	) private pure returns (bool) {
 		bytes32 messageDigest = keccak256(
 			abi.encodePacked("\x19Ethereum Signed Message:\n32", _theHash)
 		);
@@ -104,7 +104,7 @@ contract Peggy {
 		uint256[] memory _powers,
 		uint256 _valsetNonce,
 		bytes32 _peggyId
-	) public pure returns (bytes32) {
+	) private pure returns (bytes32) {
 		// bytes32 encoding of the string "checkpoint"
 		bytes32 methodName = 0x636865636b706f696e7400000000000000000000000000000000000000000000;
 
@@ -126,7 +126,7 @@ contract Peggy {
 		// This is what we are checking they have signed
 		bytes32 _theHash,
 		uint256 _powerThreshold
-	) public pure returns (bool) {
+	) private pure returns (bool) {
 		uint256 cumulativePower = 0;
 
 		for (uint256 k = 0; k < _currentValidators.length; k = k.add(1)) {

--- a/solidity/contracts/Peggy.sol
+++ b/solidity/contracts/Peggy.sol
@@ -131,18 +131,18 @@ contract Peggy {
 	) private pure {
 		uint256 cumulativePower = 0;
 
-		for (uint256 k = 0; k < _currentValidators.length; k++) {
+		for (uint256 i = 0; i < _currentValidators.length; i++) {
 			// If v is set to 0, this signifies that it was not possible to get a signature from this validator and we skip evaluation
 			// (In a valid signature, it is either 27 or 28)
-			if (_v[k] != 0) {
+			if (_v[i] != 0) {
 				// Check that the current validator has signed off on the hash
 				require(
-					verifySig(_currentValidators[k], _theHash, _v[k], _r[k], _s[k]),
+					verifySig(_currentValidators[i], _theHash, _v[i], _r[i], _s[i]),
 					"Validator signature does not match."
 				);
 
 				// Sum up cumulative power
-				cumulativePower = cumulativePower + _currentPowers[k];
+				cumulativePower = cumulativePower + _currentPowers[i];
 
 				// Break early to avoid wasting gas
 				if (cumulativePower > _powerThreshold) {
@@ -376,8 +376,8 @@ contract Peggy {
 		// Check cumulative power to ensure the contract has sufficient power to actually
 		// pass a vote
 		uint256 cumulativePower = 0;
-		for (uint256 k = 0; k < _powers.length; k++) {
-			cumulativePower = cumulativePower + _powers[k];
+		for (uint256 i = 0; i < _powers.length; i++) {
+			cumulativePower = cumulativePower + _powers[i];
 			if (cumulativePower > _powerThreshold) {
 				break;
 			}

--- a/solidity/contracts/Peggy.sol
+++ b/solidity/contracts/Peggy.sol
@@ -162,7 +162,7 @@ contract Peggy {
 	// This updates the valset by checking that the validators in the current valset have signed off on the
 	// new valset. The signatures supplied are the signatures of the current valset over the checkpoint hash
 	// generated from the new valset.
-	// Anyone can call this function, but they must supply valid signatures of 2/3s of the current valset over
+	// Anyone can call this function, but they must supply valid signatures of state_powerThreshold of the current valset over
 	// the new valset.
 	function updateValset(
 		// The new version of the validator set
@@ -243,7 +243,7 @@ contract Peggy {
 
 	// submitBatch processes a batch of Cosmos -> Ethereum transactions by sending the tokens in the transactions
 	// to the destination addresses. It is approved by the current Cosmos validator set.
-	// Anyone can call this function, but they must supply valid signatures of 2/3s of the current valset over
+	// Anyone can call this function, but they must supply valid signatures of state_powerThreshold of the current valset over
 	// the batch.
 	function submitBatch(
 		// The validators that approve the batch

--- a/solidity/contracts/contract-explanation.md
+++ b/solidity/contracts/contract-explanation.md
@@ -12,9 +12,9 @@ Usage example:
 
 ## Security model
 
-The Peggy contract is basically a multisig with a few tweaks. Even though it is designed to be used with a consensus process on Tendermint, the Peggy contract itself encodes nothing about this consensus process. There are three main operations- updateValset, updateValsetAndSubmitBatch, and sendToCosmos. 
+The Peggy contract is basically a multisig with a few tweaks. Even though it is designed to be used with a consensus process on Tendermint, the Peggy contract itself encodes nothing about this consensus process. There are three main operations- updateValset, submitBatch, and sendToCosmos. 
 - updateValset updates the signers on the multisig, and their relative powers. This mirrors the validator set on the Tendermint chain, so that all the Tendermint validators are signers, in proportion to their staking power on the Tendermint chain. An updateValset transaction must be signed by 2/3's of the current valset to be accepted.
-- updateValsetAndSubmitBatch is used to submit a batch of transactions unlocking and transferring tokens to Ethereum addresses. It is used to send tokens from Cosmos to Ethereum. The batch must be signed by 2/3's of the current valset. It also updates the valset, since it does not cost much more in gas once the validator signatures have been verified.
+- submitBatch is used to submit a batch of transactions unlocking and transferring tokens to Ethereum addresses. It is used to send tokens from Cosmos to Ethereum. The batch must be signed by 2/3's of the current valset.
 - sendToCosmos is used to send tokens onto the Tendermint chain. It simply locks the tokens in the contract and emits an event which is picked up by the Tendermint validators.
 
 ### updateValset
@@ -33,7 +33,7 @@ If we have a signature for a validator, we verify it, throwing an error if there
 
 At this point, all of the checks are complete, and it's time to update the valset! This is a bit anticlimactic, since all we do is save the new checkpoint over the old one. An event is also emitted.
 
-### updateValsetAndSubmitBatch
+### submitBatch
 
 This is how the bridge transfers tokens from addresses on the Tendermint chain to addresses on the Ethereum chain. The Cosmos validators sign batches of transactions that are submitted to the contract. Each transaction has a destination address, an amount, a nonce, and a fee for whoever submitted the batch.
 
@@ -63,4 +63,4 @@ This is emitted every time someone sends tokens to the contract to be bridged to
 
 ### ValsetUpdatedEvent
 
-This is emitted whenever the valset is updated. It does not contain the _eventNonce, since it is never brought into the Tendermint state. It is used by relayers when they call updateValsetAndSubmitBatch or updateValset, so that they can include the correct validator signatures with the transaction.
+This is emitted whenever the valset is updated. It does not contain the _eventNonce, since it is never brought into the Tendermint state. It is used by relayers when they call submitBatch or updateValset, so that they can include the correct validator signatures with the transaction.

--- a/solidity/test/happy-path.ts
+++ b/solidity/test/happy-path.ts
@@ -14,7 +14,7 @@ chai.use(solidity);
 const { expect } = chai;
 
 
-describe.only("Peggy happy path with combination method", function () {
+describe("Peggy happy path with combination method", function () {
   it("Happy path", async function () {
 
     // DEPLOY CONTRACTS

--- a/solidity/test/happy-path.ts
+++ b/solidity/test/happy-path.ts
@@ -89,27 +89,6 @@ describe("Peggy happy path with combination method", function () {
     // SUBMITBATCH
     // ==========================
 
-    // const valset2 = (() => {
-    //   // Make new valset by modifying some powers
-    //   let powers = examplePowers();
-    //   powers[0] -= 6;
-    //   powers[1] += 6;
-    //   let validators = signers.slice(0, powers.length);
-
-    //   return {
-    //     powers: powers,
-    //     validators: validators,
-    //     nonce: 2
-    //   }
-    // })()
-
-    // const checkpoint2 = makeCheckpoint(
-    //   await getSignerAddresses(valset2.validators),
-    //   valset2.powers,
-    //   valset2.nonce,
-    //   peggyId
-    // );
-
     // Transfer out to Cosmos, locking coins
     await testERC20.functions.approve(peggy.address, 1000);
     await peggy.functions.sendToCosmos(

--- a/solidity/test/happy-path.ts
+++ b/solidity/test/happy-path.ts
@@ -14,7 +14,7 @@ chai.use(solidity);
 const { expect } = chai;
 
 
-describe("Peggy happy path with combination method", function () {
+describe.only("Peggy happy path with combination method", function () {
   it("Happy path", async function () {
 
     // DEPLOY CONTRACTS
@@ -86,29 +86,29 @@ describe("Peggy happy path with combination method", function () {
 
 
 
-    // UDPATEVALSETANDSUBMITBATCH
+    // SUBMITBATCH
     // ==========================
 
-    const valset2 = (() => {
-      // Make new valset by modifying some powers
-      let powers = examplePowers();
-      powers[0] -= 6;
-      powers[1] += 6;
-      let validators = signers.slice(0, powers.length);
+    // const valset2 = (() => {
+    //   // Make new valset by modifying some powers
+    //   let powers = examplePowers();
+    //   powers[0] -= 6;
+    //   powers[1] += 6;
+    //   let validators = signers.slice(0, powers.length);
 
-      return {
-        powers: powers,
-        validators: validators,
-        nonce: 2
-      }
-    })()
+    //   return {
+    //     powers: powers,
+    //     validators: validators,
+    //     nonce: 2
+    //   }
+    // })()
 
-    const checkpoint2 = makeCheckpoint(
-      await getSignerAddresses(valset2.validators),
-      valset2.powers,
-      valset2.nonce,
-      peggyId
-    );
+    // const checkpoint2 = makeCheckpoint(
+    //   await getSignerAddresses(valset2.validators),
+    //   valset2.powers,
+    //   valset2.nonce,
+    //   peggyId
+    // );
 
     // Transfer out to Cosmos, locking coins
     await testERC20.functions.approve(peggy.address, 1000);
@@ -134,12 +134,11 @@ describe("Peggy happy path with combination method", function () {
     const batchNonce = 1
 
     const methodName = ethers.utils.formatBytes32String(
-      "valsetAndTransactionBatch"
+      "transactionBatch"
     );
 
     let abiEncoded = ethers.utils.defaultAbiCoder.encode(
       [
-        "bytes32",
         "bytes32",
         "bytes32",
         "uint256[]",
@@ -151,7 +150,6 @@ describe("Peggy happy path with combination method", function () {
       [
         peggyId,
         methodName,
-        checkpoint2,
         txAmounts,
         txDestinations,
         txFees,
@@ -162,13 +160,13 @@ describe("Peggy happy path with combination method", function () {
 
     let digest = ethers.utils.keccak256(abiEncoded);
 
-    let sigs = await signHash(valset2.validators, digest);
+    let sigs = await signHash(valset1.validators, digest);
 
-    await peggy.updateValsetAndSubmitBatch(
+    await peggy.submitBatch(
 
-      await getSignerAddresses(valset2.validators),
-      valset2.powers,
-      valset2.nonce,
+      // await getSignerAddresses(valset2.validators),
+      // valset2.powers,
+      // valset2.nonce,
 
       await getSignerAddresses(valset1.validators),
       valset1.powers,
@@ -185,7 +183,7 @@ describe("Peggy happy path with combination method", function () {
       testERC20.address
     );
 
-    expect(await peggy.functions.state_lastValsetCheckpoint()).to.equal(checkpoint2);
+    // expect(await peggy.functions.state_lastValsetCheckpoint()).to.equal(checkpoint2);
 
     expect(
       await (

--- a/solidity/test/sendToCosmos.ts
+++ b/solidity/test/sendToCosmos.ts
@@ -72,7 +72,7 @@ async function runTest(opts: {}) {
   expect(await peggy.functions.state_lastEventNonce()).to.equal(2);
 }
 
-describe("updateValsetAndSubmitBatch tests", function () {
+describe("sendToCosmos tests", function () {
   it("works right", async function () {
     await runTest({})
   });

--- a/solidity/test/submitBatch.ts
+++ b/solidity/test/submitBatch.ts
@@ -173,7 +173,7 @@ async function runTest(opts: {
   );
 }
 
-describe("updateValsetAndSubmitBatch tests", function () {
+describe("submitBatch tests", function () {
   it("throws on malformed current valset", async function () {
     await expect(runTest({ malformedCurrentValset: true })).to.be.revertedWith(
       "Malformed current validator set"


### PR DESCRIPTION
EDIT: This PR also now makes the changes requested by the Certik auditors

This issue is described [here](https://github.com/althea-net/peggy/issues/112). This PR updates the Solidity to fix this issue by taking valset updates out of submitBatch. However, it does not update the Rust or Go. 

Here is the necessary information to get `batch_test.go` working again once the rest of the Go is updated. Contact @jtremback if you need more information on how the test works. Basically, a correct hashing of a batch will result in the `batchDigest` string below, if the `tokenContract` address used matches up with what's below.

`tokenContract: 0x34Ac3eB6180FdD94043664C22043F004734Dc480`
`batchDigest: 0x731fc6e7e13e4c4bd45664c9272d49e5a9b55bccb54cfcc0704465f9de491e86`