### PR TITLE
Get PeggyID from blockchain params on deploy

### DIFF
--- a/module/x/peggy/keeper/querier.go
+++ b/module/x/peggy/keeper/querier.go
@@ -27,6 +27,7 @@ const (
 	// used to deploy eth contract
 	QueryCurrentValset = "currentValset"
 	QueryValsetConfirm = "valsetConfirm"
+	QueryPeggyID       = "peggyID"
 
 	// Batches
 
@@ -34,10 +35,6 @@ const (
 	QueryLastPendingBatchRequestByAddr = "lastPendingBatchRequest"
 	QueryOutgoingTxBatches             = "lastBatches"
 	QueryBatchConfirms                 = "batchConfirms"
-
-	// Other
-
-	QueryBridgedDenominators = "allBridgedDenominators"
 )
 
 // NewQuerier is the module level router for state queries
@@ -68,6 +65,9 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 			return lastPendingBatchRequest(ctx, path[1], keeper) // Tested (lightly)
 		case QueryOutgoingTxBatches:
 			return lastBatchesRequest(ctx, keeper) // Tested (lightly)
+
+		case QueryPeggyID:
+			return queryPeggyID(ctx, keeper)
 
 		default:
 			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint", types.ModuleName)
@@ -321,4 +321,14 @@ func queryBatch(ctx sdk.Context, nonce string, tokenContract string, keeper Keep
 		return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, err.Error())
 	}
 	return res, nil
+}
+
+func queryPeggyID(ctx sdk.Context, keeper Keeper) ([]byte, error) {
+	peggyID := keeper.GetPeggyID(ctx)
+	res, err := codec.MarshalJSONIndent(types.ModuleCdc, peggyID)
+	if err != nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+	} else {
+		return res, nil
+	}
 }

--- a/orchestrator/orchestrator/src/test_runner.rs
+++ b/orchestrator/orchestrator/src/test_runner.rs
@@ -100,7 +100,6 @@ const COSMOS_NODE: &str = "http://localhost:1317";
 const COSMOS_NODE_GRPC: &str = "http://localhost:9090";
 const COSMOS_NODE_ABCI: &str = "http://localhost:26657";
 const ETH_NODE: &str = "http://localhost:8545";
-const PEGGY_ID: &str = "defaultpeggyid";
 
 lazy_static! {
     // this key is the private key for the public key defined in tests/assets/ETHGenesis.json
@@ -281,7 +280,6 @@ async fn deploy_contracts(
             &format!("--cosmos-node={}", COSMOS_NODE_ABCI),
             &format!("--eth-node={}", ETH_NODE),
             &format!("--eth-privkey={:#x}", *MINER_PRIVATE_KEY),
-            &format!("--peggy-id={}", PEGGY_ID),
             "--contract=/peggy/solidity/artifacts/Peggy.json",
             "--erc20-contract=/peggy/solidity/artifacts/TestERC20.json",
             "--test-mode=true",


### PR DESCRIPTION
This patch modifies the contract deployer script to retrieve the
PeggyID from the chain parameters using a new ABCI endpoint also
included in this patch.

This allows for the chain to select a PeggyID either by placing it
into a genesis file or by voting on it as a governance paramater
after the chain starts but before the Peggy contract is deployed.

On deployment the contract deployer will retrieve the PeggyID from
the chain and the value will then be fixed in the contract storage.

At some point we should probably forbid deployments of the defualt
peggy ID in the deployment script outside of test mode. To prevent
possible failures where validators on multiple peggy chains find
signatures intended for one Peggy contract being used against another.