### PR TITLE
Move Peggy.sol nonce checks to the top

### DIFF
--- a/solidity/contracts/Peggy.sol
+++ b/solidity/contracts/Peggy.sol
@@ -180,6 +180,12 @@ contract Peggy {
 	) public {
 		// CHECKS
 
+		// Check that the valset nonce is greater than the old one
+		require(
+			_newValsetNonce > _currentValsetNonce,
+			"New valset nonce must be greater than the current nonce"
+		);
+
 		// Check that new validators and powers set is well-formed
 		require(_newValidators.length == _newPowers.length, "Malformed new validator set");
 
@@ -201,12 +207,6 @@ contract Peggy {
 				state_peggyId
 			) == state_lastValsetCheckpoint,
 			"Supplied current validators and powers do not match checkpoint."
-		);
-
-		// Check that the valset nonce is greater than the old one
-		require(
-			_newValsetNonce > _currentValsetNonce,
-			"New valset nonce must be greater than the current nonce"
 		);
 
 		// Check that enough current validators have signed off on the new validator set
@@ -263,6 +263,12 @@ contract Peggy {
 	) public {
 		// CHECKS scoped to reduce stack depth
 		{
+			// Check that the batch nonce is higher than the last nonce for this token
+			require(
+				state_lastBatchNonces[_tokenContract] < _batchNonce,
+				"New batch nonce must be greater than the current nonce"
+			);
+
 			// Check that current validators, powers, and signatures (v,r,s) set is well-formed
 			require(
 				_currentValidators.length == _currentPowers.length &&
@@ -287,12 +293,6 @@ contract Peggy {
 			require(
 				_amounts.length == _destinations.length && _amounts.length == _fees.length,
 				"Malformed batch of transactions"
-			);
-
-			// Check that the batch nonce is higher than the last nonce for this token
-			require(
-				state_lastBatchNonces[_tokenContract] < _batchNonce,
-				"New batch nonce must be greater than the current nonce"
 			);
 
 			// Check that enough current validators have signed off on the transaction batch and valset

--- a/solidity/test/updateValset.ts
+++ b/solidity/test/updateValset.ts
@@ -50,7 +50,7 @@ async function runTest(opts: {
 
   let currentValsetNonce = 0;
   if (opts.nonMatchingCurrentValset) {
-    currentValsetNonce = 420;
+    powers[0] = 78;
   }
   let newValsetNonce = 1;
   if (opts.nonceNotIncremented) {


### PR DESCRIPTION
It's an unfortunate reality of our design that many relayers will
race to submit any given batch or validator set update. Since these
are valid transactions with their own nonces and gas fees they will
be accepted by the Ethereum blockchain only to have the contract throw
shortly into their execution.

While we can't prevent this we can at least take the sting out of it.
Previously basic nonce checks where placed after checkpoint creation
meaning that with a 125 member validator set a submitter may pay $10
-$15 to hash every validiators address and then figure out with a
single integer comparison that the validator set being submitted is
the current nonce.

This patch corrects that issue by moving nonce checking as high as
possible. This should minimize gas costs for failures to only the
argument cost, base transaction fee, and one comparison.