### PR TITLE
WIP add claims storage

### DIFF
--- a/module/proto/peggy/v1/types.proto
+++ b/module/proto/peggy/v1/types.proto
@@ -15,3 +15,15 @@ message Valset {
   uint64                   nonce   = 1;
   repeated BridgeValidator members = 2;
 }
+
+// It's difficult to serialize and deserialize
+// interfaces, instead we can make this struct
+// that stores all the data the interface requires
+// and use it to store and then re-create a interface
+// object with all the same properties.
+message GenericClaim {
+  uint64  event_nonce = 1;
+  int32   claim_type = 2;
+  bytes   hash = 3;
+  string  event_claimer = 4;
+}

--- a/module/x/peggy/handler_test.go
+++ b/module/x/peggy/handler_test.go
@@ -133,7 +133,7 @@ func TestHandleCreateEthereumClaimsSingleValidator(t *testing.T) {
 	_, err := h(ctx, &ethClaim)
 	require.NoError(t, err)
 	// and claim persisted
-	claimFound := k.HasClaim(ctx, types.CLAIM_TYPE_DEPOSIT, myNonce, myValAddr, &ethClaim)
+	claimFound := k.HasClaim(ctx, &ethClaim)
 	assert.True(t, claimFound)
 	// and attestation persisted
 	a := k.GetAttestation(ctx, myNonce, &ethClaim)
@@ -241,7 +241,7 @@ func TestHandleCreateEthereumClaimsMultiValidator(t *testing.T) {
 	_, err := h(ctx, &ethClaim1)
 	require.NoError(t, err)
 	// and claim persisted
-	claimFound1 := k.HasClaim(ctx, types.CLAIM_TYPE_DEPOSIT, myNonce, valAddr1, &ethClaim1)
+	claimFound1 := k.HasClaim(ctx, &ethClaim1)
 	assert.True(t, claimFound1)
 	// and attestation persisted
 	a1 := k.GetAttestation(ctx, myNonce, &ethClaim1)
@@ -256,7 +256,7 @@ func TestHandleCreateEthereumClaimsMultiValidator(t *testing.T) {
 	require.NoError(t, err)
 
 	// and claim persisted
-	claimFound2 := k.HasClaim(ctx, types.CLAIM_TYPE_DEPOSIT, myNonce, valAddr1, &ethClaim2)
+	claimFound2 := k.HasClaim(ctx, &ethClaim2)
 	assert.True(t, claimFound2)
 	// and attestation persisted
 	a2 := k.GetAttestation(ctx, myNonce, &ethClaim1)
@@ -271,7 +271,7 @@ func TestHandleCreateEthereumClaimsMultiValidator(t *testing.T) {
 	require.NoError(t, err)
 
 	// and claim persisted
-	claimFound3 := k.HasClaim(ctx, types.CLAIM_TYPE_DEPOSIT, myNonce, valAddr1, &ethClaim2)
+	claimFound3 := k.HasClaim(ctx, &ethClaim2)
 	assert.True(t, claimFound3)
 	// and attestation persisted
 	a3 := k.GetAttestation(ctx, myNonce, &ethClaim1)

--- a/module/x/peggy/keeper/attestation.go
+++ b/module/x/peggy/keeper/attestation.go
@@ -16,12 +16,12 @@ import (
 // - Checks if the attestation has enough votes to be considered "Observed", then attempts to apply it to the
 //   consensus state (e.g. minting tokens for a deposit event)
 // - If so, marks it "Observed" and emits an event
-func (k Keeper) AddClaim(ctx sdk.Context, claimType types.ClaimType, eventNonce uint64, validator sdk.ValAddress, details types.EthereumClaim) (*types.Attestation, error) {
-	if err := k.storeClaim(ctx, claimType, eventNonce, validator, details); err != nil {
+func (k Keeper) AddClaim(ctx sdk.Context, details types.EthereumClaim) (*types.Attestation, error) {
+	if err := k.storeClaim(ctx, details); err != nil {
 		return nil, sdkerrors.Wrap(err, "claim")
 	}
 
-	att := k.voteForAttestation(ctx, claimType, eventNonce, details, validator)
+	att := k.voteForAttestation(ctx, details)
 
 	k.tryAttestation(ctx, att, details)
 
@@ -31,22 +31,19 @@ func (k Keeper) AddClaim(ctx sdk.Context, claimType types.ClaimType, eventNonce 
 }
 
 // storeClaim persists a claim. Fails when a claim submitted by an Eth signer does not increment the event nonce by exactly 1.
-func (k Keeper) storeClaim(ctx sdk.Context, claimType types.ClaimType, eventNonce uint64, validator sdk.ValAddress, details types.EthereumClaim) error {
+func (k Keeper) storeClaim(ctx sdk.Context, details types.EthereumClaim) error {
 	// Check that the nonce of this event is exactly one higher than the last nonce stored by this validator.
 	// We check the event nonce in processAttestation as well, but checking it here gives individual eth signers a chance to retry.
-	lastEventNonce := k.GetLastEventNonceByValidator(ctx, validator)
-	if eventNonce != lastEventNonce+1 {
+	lastEventNonce := k.GetLastEventNonceByValidator(ctx, sdk.ValAddress(details.GetClaimer()))
+	if details.GetEventNonce() != lastEventNonce+1 {
 		return types.ErrNonContiguousEventNonce
 	}
-	k.setLastEventNonceByValidator(ctx, validator, eventNonce)
-
-	// Store this nonce and the claim
-	// TODO: This is not actually storing the claim. It can only be used to check if we have stored the same claim before.
-	// We need to think this through more. This will be used for slashing later.
+	k.setLastEventNonceByValidator(ctx, sdk.ValAddress(details.GetClaimer()), details.GetEventNonce())
+	// Store the claim
+	genericClaim, _ := types.GenericClaimfromInterface(details)
 	store := ctx.KVStore(k.storeKey)
-	cKey := types.GetClaimKey(claimType, eventNonce, validator, details)
-	// TODO: we need to store this claim here, need to change this index
-	store.Set(cKey, []byte{}) // empty as all payload is in the key already (no gas costs)
+	cKey := types.GetClaimKey(details)
+	store.Set(cKey, k.cdc.MustMarshalBinaryBare(genericClaim))
 	return nil
 }
 
@@ -54,24 +51,21 @@ func (k Keeper) storeClaim(ctx sdk.Context, claimType types.ClaimType, eventNonc
 // has submitted a claim for this exact event
 func (k Keeper) voteForAttestation(
 	ctx sdk.Context,
-	claimType types.ClaimType,
-	eventNonce uint64,
 	details types.EthereumClaim,
-	validator sdk.ValAddress,
 ) *types.Attestation {
 	// Tries to get an attestation with the same eventNonce and details as the claim that was submitted.
-	att := k.GetAttestation(ctx, eventNonce, details)
+	att := k.GetAttestation(ctx, details.GetEventNonce(), details)
 
 	// If it does not exist, create a new one.
 	if att == nil {
 		att = &types.Attestation{
-			EventNonce: uint64(eventNonce),
+			EventNonce: details.GetEventNonce(),
 			Observed:   false,
 		}
 	}
 
 	// Add the validator's vote to this attestation
-	att.Votes = append(att.Votes, validator.String())
+	att.Votes = append(att.Votes, details.GetClaimer().String())
 
 	return att
 }
@@ -214,7 +208,7 @@ func (k Keeper) setLastEventNonceByValidator(ctx sdk.Context, validator sdk.ValA
 }
 
 // HasClaim returns true if a claim exists
-func (k Keeper) HasClaim(ctx sdk.Context, claimType types.ClaimType, nonce uint64, validator sdk.ValAddress, details types.EthereumClaim) bool {
+func (k Keeper) HasClaim(ctx sdk.Context, details types.EthereumClaim) bool {
 	store := ctx.KVStore(k.storeKey)
-	return store.Has(types.GetClaimKey(claimType, nonce, validator, details))
+	return store.Has(types.GetClaimKey(details))
 }

--- a/module/x/peggy/keeper/msg_server.go
+++ b/module/x/peggy/keeper/msg_server.go
@@ -235,13 +235,13 @@ func (k msgServer) DepositClaim(c context.Context, msg *types.MsgDepositClaim) (
 	val := k.StakingKeeper.Validator(ctx, validator)
 	switch {
 	case val == nil:
-		return nil, sdkerrors.Wrap(sdkerrors.ErrorInvalidSigner, "validator not in acitve set")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrorInvalidSigner, "validator not in active set")
 	case !val.IsBonded():
-		return nil, sdkerrors.Wrap(sdkerrors.ErrorInvalidSigner, "validator not in acitve set")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrorInvalidSigner, "validator not in active set")
 	}
 
 	// Add the claim to the store
-	att, err := k.AddClaim(ctx, msg.GetType(), msg.GetEventNonce(), validator, msg)
+	att, err := k.AddClaim(ctx, msg)
 	if err != nil {
 		return nil, sdkerrors.Wrap(err, "create attestation")
 	}
@@ -280,7 +280,7 @@ func (k msgServer) WithdrawClaim(c context.Context, msg *types.MsgWithdrawClaim)
 	}
 
 	// Add the claim to the store
-	att, err := k.AddClaim(ctx, msg.GetType(), msg.GetEventNonce(), validator, msg)
+	att, err := k.AddClaim(ctx, msg)
 	if err != nil {
 		return nil, sdkerrors.Wrap(err, "create attestation")
 	}

--- a/module/x/peggy/types/key.go
+++ b/module/x/peggy/types/key.go
@@ -95,19 +95,19 @@ func GetValsetConfirmKey(nonce uint64, validator sdk.AccAddress) []byte {
 // prefix type               cosmos-validator-address                       nonce                             attestation-details-hash
 // [0x0][0 0 0 1][cosmosvaloper1ahx7f8wyertuus9r20284ej0asrs085case3kn][0 0 0 0 0 0 0 1][fd1af8cec6c67fcf156f1b61fdf91ebc04d05484d007436e75342fc05bbff35a]
 // TODO: remove the validator address usage here!
-func GetClaimKey(claimType ClaimType, nonce uint64, validator sdk.ValAddress, details EthereumClaim) []byte {
+func GetClaimKey(details EthereumClaim) []byte {
 	var detailsHash []byte
 	if details != nil {
 		detailsHash = details.ClaimHash()
 	} else {
 		panic("No claim without details!")
 	}
-	claimTypeLen := len([]byte{byte(claimType)})
-	nonceBz := UInt64Bytes(nonce)
+	claimTypeLen := len([]byte{byte(details.GetType())})
+	nonceBz := UInt64Bytes(details.GetEventNonce())
 	key := make([]byte, len(OracleClaimKey)+claimTypeLen+sdk.AddrLen+len(nonceBz)+len(detailsHash))
 	copy(key[0:], OracleClaimKey)
-	copy(key[len(OracleClaimKey):], []byte{byte(claimType)})
-	copy(key[len(OracleClaimKey)+claimTypeLen:], validator)
+	copy(key[len(OracleClaimKey):], []byte{byte(details.GetType())})
+	copy(key[len(OracleClaimKey)+claimTypeLen:], details.GetClaimer())
 	copy(key[len(OracleClaimKey)+claimTypeLen+sdk.AddrLen:], nonceBz)
 	copy(key[len(OracleClaimKey)+claimTypeLen+sdk.AddrLen+len(nonceBz):], detailsHash)
 	return key

--- a/module/x/peggy/types/msgs.pb.gw.go
+++ b/module/x/peggy/types/msgs.pb.gw.go
@@ -322,7 +322,6 @@ func local_request_Msg_WithdrawClaim_0(ctx context.Context, marshaler runtime.Ma
 // RegisterMsgHandlerServer registers the http handlers for service Msg to "mux".
 // UnaryRPC     :call MsgServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
-// Note that using this registration option will cause many gRPC library features (such as grpc.SendHeader, etc) to stop working. Consider using RegisterMsgHandlerFromEndpoint instead.
 func RegisterMsgHandlerServer(ctx context.Context, mux *runtime.ServeMux, server MsgServer) error {
 
 	mux.Handle("POST", pattern_Msg_ValsetConfirm_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {

--- a/module/x/peggy/types/query.pb.gw.go
+++ b/module/x/peggy/types/query.pb.gw.go
@@ -484,7 +484,6 @@ func local_request_Query_BatchConfirms_0(ctx context.Context, marshaler runtime.
 // RegisterQueryHandlerServer registers the http handlers for service Query to "mux".
 // UnaryRPC     :call QueryServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
-// Note that using this registration option will cause many gRPC library features (such as grpc.SendHeader, etc) to stop working. Consider using RegisterQueryHandlerFromEndpoint instead.
 func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, server QueryServer) error {
 
 	mux.Handle("GET", pattern_Query_Params_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {

--- a/module/x/peggy/types/types.pb.go
+++ b/module/x/peggy/types/types.pb.go
@@ -130,31 +130,110 @@ func (m *Valset) GetMembers() []*BridgeValidator {
 	return nil
 }
 
+// It's difficult to serialize and deserialize
+// interfaces, instead we can make this struct
+// that stores all the data the interface requires
+// and use it to store and then re-create a interface
+// object with all the same properties.
+type GenericClaim struct {
+	EventNonce   uint64 `protobuf:"varint,1,opt,name=event_nonce,json=eventNonce,proto3" json:"event_nonce,omitempty"`
+	ClaimType    int32  `protobuf:"varint,2,opt,name=claim_type,json=claimType,proto3" json:"claim_type,omitempty"`
+	Hash         []byte `protobuf:"bytes,3,opt,name=hash,proto3" json:"hash,omitempty"`
+	EventClaimer string `protobuf:"bytes,4,opt,name=event_claimer,json=eventClaimer,proto3" json:"event_claimer,omitempty"`
+}
+
+func (m *GenericClaim) Reset()         { *m = GenericClaim{} }
+func (m *GenericClaim) String() string { return proto.CompactTextString(m) }
+func (*GenericClaim) ProtoMessage()    {}
+func (*GenericClaim) Descriptor() ([]byte, []int) {
+	return fileDescriptor_1488ca6080c6185d, []int{2}
+}
+func (m *GenericClaim) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GenericClaim) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GenericClaim.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GenericClaim) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GenericClaim.Merge(m, src)
+}
+func (m *GenericClaim) XXX_Size() int {
+	return m.Size()
+}
+func (m *GenericClaim) XXX_DiscardUnknown() {
+	xxx_messageInfo_GenericClaim.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GenericClaim proto.InternalMessageInfo
+
+func (m *GenericClaim) GetEventNonce() uint64 {
+	if m != nil {
+		return m.EventNonce
+	}
+	return 0
+}
+
+func (m *GenericClaim) GetClaimType() int32 {
+	if m != nil {
+		return m.ClaimType
+	}
+	return 0
+}
+
+func (m *GenericClaim) GetHash() []byte {
+	if m != nil {
+		return m.Hash
+	}
+	return nil
+}
+
+func (m *GenericClaim) GetEventClaimer() string {
+	if m != nil {
+		return m.EventClaimer
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*BridgeValidator)(nil), "peggy.v1.BridgeValidator")
 	proto.RegisterType((*Valset)(nil), "peggy.v1.Valset")
+	proto.RegisterType((*GenericClaim)(nil), "peggy.v1.GenericClaim")
 }
 
 func init() { proto.RegisterFile("peggy/v1/types.proto", fileDescriptor_1488ca6080c6185d) }
 
 var fileDescriptor_1488ca6080c6185d = []byte{
-	// 241 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x29, 0x48, 0x4d, 0x4f,
-	0xaf, 0xd4, 0x2f, 0x33, 0xd4, 0x2f, 0xa9, 0x2c, 0x48, 0x2d, 0xd6, 0x2b, 0x28, 0xca, 0x2f, 0xc9,
-	0x17, 0xe2, 0x00, 0x8b, 0xea, 0x95, 0x19, 0x2a, 0x05, 0x71, 0xf1, 0x3b, 0x15, 0x65, 0xa6, 0xa4,
-	0xa7, 0x86, 0x25, 0xe6, 0x64, 0xa6, 0x24, 0x96, 0xe4, 0x17, 0x09, 0x89, 0x70, 0xb1, 0x16, 0xe4,
-	0x97, 0xa7, 0x16, 0x49, 0x30, 0x2a, 0x30, 0x6a, 0xb0, 0x04, 0x41, 0x38, 0x42, 0x9a, 0x5c, 0x02,
-	0xa9, 0x25, 0x19, 0xa9, 0x45, 0xa9, 0xa5, 0xb9, 0xf1, 0x89, 0x29, 0x29, 0x45, 0xa9, 0xc5, 0xc5,
-	0x12, 0x4c, 0x0a, 0x8c, 0x1a, 0x9c, 0x41, 0xfc, 0x30, 0x71, 0x47, 0x88, 0xb0, 0x52, 0x30, 0x17,
-	0x5b, 0x58, 0x62, 0x4e, 0x71, 0x6a, 0x09, 0xc8, 0xa8, 0xbc, 0xfc, 0xbc, 0xe4, 0x54, 0x98, 0x51,
-	0x60, 0x8e, 0x90, 0x31, 0x17, 0x7b, 0x6e, 0x6a, 0x6e, 0x52, 0x6a, 0x11, 0xc8, 0x04, 0x66, 0x0d,
-	0x6e, 0x23, 0x49, 0x3d, 0x98, 0x7b, 0xf4, 0xd0, 0x1c, 0x13, 0x04, 0x53, 0xe9, 0xe4, 0x75, 0xe2,
-	0x91, 0x1c, 0xe3, 0x85, 0x47, 0x72, 0x8c, 0x0f, 0x1e, 0xc9, 0x31, 0x4e, 0x78, 0x2c, 0xc7, 0x70,
-	0xe1, 0xb1, 0x1c, 0xc3, 0x8d, 0xc7, 0x72, 0x0c, 0x51, 0x06, 0xe9, 0x99, 0x25, 0x19, 0xa5, 0x49,
-	0x7a, 0xc9, 0xf9, 0xb9, 0xfa, 0x89, 0x39, 0x25, 0x19, 0xa9, 0x89, 0xba, 0x79, 0xa9, 0x25, 0xfa,
-	0x10, 0x8f, 0xe7, 0xe6, 0xa7, 0x94, 0xe6, 0xa4, 0xea, 0x57, 0x40, 0xb9, 0xe0, 0x40, 0x48, 0x62,
-	0x03, 0x87, 0x82, 0x31, 0x20, 0x00, 0x00, 0xff, 0xff, 0x47, 0x58, 0x87, 0xfa, 0x1d, 0x01, 0x00,
-	0x00,
+	// 323 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x5c, 0x91, 0xbf, 0x4e, 0xf3, 0x30,
+	0x14, 0xc5, 0xeb, 0xaf, 0x7f, 0x3e, 0x7a, 0x5b, 0x54, 0x64, 0x75, 0x08, 0x03, 0xa1, 0x2a, 0x4b,
+	0x18, 0x48, 0x28, 0x7d, 0x02, 0xda, 0x01, 0x89, 0x81, 0x21, 0xa0, 0x0e, 0x2c, 0x95, 0x9b, 0x5c,
+	0x25, 0x91, 0xe2, 0x38, 0x72, 0xdc, 0x42, 0x9f, 0x80, 0x95, 0xc7, 0x62, 0xec, 0xc8, 0x88, 0xda,
+	0x17, 0x41, 0xb9, 0x21, 0x12, 0x62, 0xf3, 0xf9, 0xe9, 0xe8, 0xf8, 0x5c, 0x1d, 0x18, 0xe6, 0x18,
+	0x45, 0x5b, 0x6f, 0x33, 0xf1, 0xcc, 0x36, 0xc7, 0xc2, 0xcd, 0xb5, 0x32, 0x8a, 0x1f, 0x11, 0x75,
+	0x37, 0x93, 0xb1, 0x0f, 0x83, 0x99, 0x4e, 0xc2, 0x08, 0x17, 0x22, 0x4d, 0x42, 0x61, 0x94, 0xe6,
+	0x43, 0x68, 0xe7, 0xea, 0x05, 0xb5, 0xc5, 0x46, 0xcc, 0x69, 0xf9, 0x95, 0xe0, 0x97, 0x70, 0x82,
+	0x26, 0x46, 0x8d, 0x6b, 0xb9, 0x14, 0x61, 0xa8, 0xb1, 0x28, 0xac, 0x7f, 0x23, 0xe6, 0x74, 0xfd,
+	0x41, 0xcd, 0x6f, 0x2b, 0x3c, 0x7e, 0x84, 0xce, 0x42, 0xa4, 0x05, 0x9a, 0x32, 0x2a, 0x53, 0x59,
+	0x80, 0x75, 0x14, 0x09, 0x3e, 0x85, 0xff, 0x12, 0xe5, 0x0a, 0x75, 0x99, 0xd0, 0x74, 0x7a, 0x37,
+	0xa7, 0x6e, 0xdd, 0xc7, 0xfd, 0x53, 0xc6, 0xaf, 0x9d, 0xe3, 0x37, 0x06, 0xfd, 0x3b, 0xcc, 0x50,
+	0x27, 0xc1, 0x3c, 0x15, 0x89, 0xe4, 0xe7, 0xd0, 0xc3, 0x0d, 0x66, 0x66, 0xf9, 0xfb, 0x07, 0x20,
+	0xf4, 0x40, 0xdf, 0x9c, 0x01, 0x04, 0xa5, 0x73, 0x59, 0x5e, 0x4e, 0x5d, 0xdb, 0x7e, 0x97, 0xc8,
+	0xd3, 0x36, 0x47, 0xce, 0xa1, 0x15, 0x8b, 0x22, 0xb6, 0x9a, 0x23, 0xe6, 0xf4, 0x7d, 0x7a, 0xf3,
+	0x0b, 0x38, 0xae, 0x32, 0xc9, 0x86, 0xda, 0x6a, 0xd1, 0x85, 0x7d, 0x82, 0xf3, 0x8a, 0xcd, 0xee,
+	0x3f, 0xf6, 0x36, 0xdb, 0xed, 0x6d, 0xf6, 0xb5, 0xb7, 0xd9, 0xfb, 0xc1, 0x6e, 0xec, 0x0e, 0x76,
+	0xe3, 0xf3, 0x60, 0x37, 0x9e, 0xaf, 0xa3, 0xc4, 0xc4, 0xeb, 0x95, 0x1b, 0x28, 0xe9, 0x89, 0xd4,
+	0xc4, 0x28, 0xae, 0x32, 0x34, 0x5e, 0x35, 0x81, 0x54, 0xe1, 0x3a, 0x45, 0xef, 0xf5, 0x47, 0xd2,
+	0x1c, 0xab, 0x0e, 0xed, 0x31, 0xfd, 0x0e, 0x00, 0x00, 0xff, 0xff, 0xd4, 0x52, 0xe0, 0x3e, 0xa7,
+	0x01, 0x00, 0x00,
 }
 
 func (m *BridgeValidator) Marshal() (dAtA []byte, err error) {
@@ -234,6 +313,53 @@ func (m *Valset) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *GenericClaim) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GenericClaim) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GenericClaim) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.EventClaimer) > 0 {
+		i -= len(m.EventClaimer)
+		copy(dAtA[i:], m.EventClaimer)
+		i = encodeVarintTypes(dAtA, i, uint64(len(m.EventClaimer)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.Hash) > 0 {
+		i -= len(m.Hash)
+		copy(dAtA[i:], m.Hash)
+		i = encodeVarintTypes(dAtA, i, uint64(len(m.Hash)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.ClaimType != 0 {
+		i = encodeVarintTypes(dAtA, i, uint64(m.ClaimType))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.EventNonce != 0 {
+		i = encodeVarintTypes(dAtA, i, uint64(m.EventNonce))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTypes(v)
 	base := offset
@@ -275,6 +401,29 @@ func (m *Valset) Size() (n int) {
 			l = e.Size()
 			n += 1 + l + sovTypes(uint64(l))
 		}
+	}
+	return n
+}
+
+func (m *GenericClaim) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.EventNonce != 0 {
+		n += 1 + sovTypes(uint64(m.EventNonce))
+	}
+	if m.ClaimType != 0 {
+		n += 1 + sovTypes(uint64(m.ClaimType))
+	}
+	l = len(m.Hash)
+	if l > 0 {
+		n += 1 + l + sovTypes(uint64(l))
+	}
+	l = len(m.EventClaimer)
+	if l > 0 {
+		n += 1 + l + sovTypes(uint64(l))
 	}
 	return n
 }
@@ -470,6 +619,163 @@ func (m *Valset) Unmarshal(dAtA []byte) error {
 			if err := m.Members[len(m.Members)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTypes(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GenericClaim) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTypes
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GenericClaim: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GenericClaim: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EventNonce", wireType)
+			}
+			m.EventNonce = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.EventNonce |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClaimType", wireType)
+			}
+			m.ClaimType = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ClaimType |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Hash", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Hash = append(m.Hash[:0], dAtA[iNdEx:postIndex]...)
+			if m.Hash == nil {
+				m.Hash = []byte{}
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EventClaimer", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.EventClaimer = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex


### PR DESCRIPTION
This patch actually stores the Ethereum claims. Serializing interface
objects is onerous so what we do is create a Proto definition for a
struct that implements the interface. In this way when you go to
load the claim you can simply take the GenericClaim struct and turn
it back into the interface object you stored.

This patch does not yet include tools for iteration and generally
doesn't work at all. This is because until key delegation is implemented
it's impossible to finish the detail work around what address type is
expected where.