### PR TITLE
Maintain sorting in order signatures

### DIFF
--- a/orchestrator/relayer/src/batch_relaying.rs
+++ b/orchestrator/relayer/src/batch_relaying.rs
@@ -62,8 +62,14 @@ pub async fn relay_batches(
         our_ethereum_address,
         web3,
     )
-    .await
-    .expect("Failed to get batch nonce from Ethereum");
+    .await;
+    if latest_ethereum_batch.is_err() {
+        error!(
+            "Failed to get latest Ethereum batch with {:?}",
+            latest_ethereum_batch
+        );
+    }
+    let latest_ethereum_batch = latest_ethereum_batch.unwrap();
     let latest_cosmos_batch_nonce = oldest_signed_batch.clone().nonce;
     if latest_cosmos_batch_nonce > latest_ethereum_batch {
         info!(

--- a/orchestrator/relayer/src/valset_relaying.rs
+++ b/orchestrator/relayer/src/valset_relaying.rs
@@ -7,7 +7,6 @@ use clarity::address::Address as EthAddress;
 use clarity::PrivateKey as EthPrivateKey;
 use cosmos_peggy::query::get_all_valset_confirms;
 use cosmos_peggy::query::get_latest_valsets;
-use ethereum_peggy::utils::get_valset_nonce;
 use ethereum_peggy::valset_update::send_eth_valset_update;
 use peggy_proto::peggy::query_client::QueryClient as PeggyQueryClient;
 use tonic::transport::Channel;
@@ -54,28 +53,24 @@ pub async fn relay_valsets(
     let latest_cosmos_confirmed = latest_confirmed.unwrap();
     let latest_cosmos_valset = latest_valset.unwrap();
 
-    let current_ethereum_valset =
-        get_valset_nonce(peggy_contract_address, our_ethereum_address, web3)
-            .await
-            .expect("Failed to get Ethereum valset");
+    let current_valset = find_latest_valset(
+        grpc_client,
+        our_ethereum_address,
+        peggy_contract_address,
+        web3,
+    )
+    .await;
+    if current_valset.is_err() {
+        error!("Could not get current valset!");
+        return;
+    }
+    let current_valset = current_valset.unwrap();
     let latest_cosmos_valset_nonce = latest_cosmos_valset.nonce;
-    if latest_cosmos_valset_nonce > current_ethereum_valset {
+    if latest_cosmos_valset_nonce > current_valset.nonce {
         info!(
             "We have detected latest valset {} but latest on Ethereum is {} sending an update!",
-            latest_cosmos_valset.nonce, current_ethereum_valset
+            latest_cosmos_valset.nonce, current_valset.nonce
         );
-        let current_valset = find_latest_valset(
-            grpc_client,
-            our_ethereum_address,
-            peggy_contract_address,
-            web3,
-        )
-        .await;
-        if current_valset.is_err() {
-            error!("Could not get current valset!");
-            return;
-        }
-        let current_valset = current_valset.unwrap();
 
         // If the ENV var NO_GAS_OPT is not set at compile time then the resulting binary will not
         // have gas optimizations. In this case if we exit early if gas optimizations are enabled


### PR DESCRIPTION
Previously order_valset_sigs and order_batch_sigs worked by iterating
over the signatures and extracting the correct validator set members
or non-signers as seperate operations.

This is both less intutive and less correct than iterating over the
validator set members and looking up the correct signatures.
Specifically it's terribly unintutive to properly order zeroed out signatures
without iterating over the validator set members first. Since they
obviously don't exist in the signatures array and don't have an
identifier other than their power to sort.

This patch should solve the ordering problem end-to-end. Now that we
are getting the last validator set from the Ethereum event rather than
the Cosmos chain so long as we maintain the order in that event when
building our signatures array then the submission must match the
previous hash.