### PR TITLE
Fix validator set stress test

### DIFF
--- a/orchestrator/test_runner/src/happy_path.rs
+++ b/orchestrator/test_runner/src/happy_path.rs
@@ -160,6 +160,9 @@ pub async fn delegate_tokens(delegate_address: &str, amount: &str) {
         .expect("Failed to update stake to trigger validator set change");
     let mut stdout = String::from_utf8_lossy(&output.stdout).to_string();
     while stdout.contains("account sequence mismatch") {
+        if stdout.contains("insufficient funds") {
+            panic!("Can't continue to produce validator sets! Not enough STAKE token")
+        }
         output = cmd
             .current_dir("/")
             .output()

--- a/tests/container-scripts/setup-validators.sh
+++ b/tests/container-scripts/setup-validators.sh
@@ -7,7 +7,7 @@ CHAIN_ID="peggy-test"
 
 NODES=$1
 
-ALLOCATION="1000000000stake,1000000000footoken"
+ALLOCATION="10000000000stake,10000000000footoken"
 
 # first we start a genesis.json with validator 1
 # validator 1 will also collect the gentx's once gnerated


### PR DESCRIPTION
This test just required some extra coins in the test env
to trigger the creation of more validator sets.