### PR TITLE
WIP: Event nonce fixes

### DIFF
--- a/module/x/peggy/keeper/attestation.go
+++ b/module/x/peggy/keeper/attestation.go
@@ -252,7 +252,11 @@ func (k Keeper) GetLastEventNonceByValidator(ctx sdk.Context, validator sdk.ValA
 	bytes := store.Get(types.GetLastEventNonceByValidatorKey(validator))
 
 	if len(bytes) == 0 {
-		return 0
+		// in the case that we have no existing value this is the first
+		// time a validator is submitting a claim. Since we don't want to force
+		// them to replay the entire history of all events ever we should start
+		// at the latest observed event on chain.
+		return k.GetLastObservedEventNonce(ctx)
 	}
 	return types.UInt64FromBytes(bytes)
 }

--- a/module/x/peggy/keeper/msg_server.go
+++ b/module/x/peggy/keeper/msg_server.go
@@ -225,6 +225,9 @@ func (k msgServer) ConfirmBatch(c context.Context, msg *types.MsgConfirmBatch) (
 }
 
 // DepositClaim handles MsgDepositClaim
+// TODO it is possible to submit an old msgDepositClaim (old defined as covering an event nonce that has already been
+// executed aka 'observed' and had it's slashing window expire) that will never be cleaned up in the endblocker. This
+// should not be a security risk as 'old' events can never execute but it does store spam in the chain.
 func (k msgServer) DepositClaim(c context.Context, msg *types.MsgDepositClaim) (*types.MsgDepositClaimResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
 
@@ -264,6 +267,9 @@ func (k msgServer) DepositClaim(c context.Context, msg *types.MsgDepositClaim) (
 }
 
 // WithdrawClaim handles MsgWithdrawClaim
+// TODO it is possible to submit an old msgWithdrawClaim (old defined as covering an event nonce that has already been
+// executed aka 'observed' and had it's slashing window expire) that will never be cleaned up in the endblocker. This
+// should not be a security risk as 'old' events can never execute but it does store spam in the chain.
 func (k msgServer) WithdrawClaim(c context.Context, msg *types.MsgWithdrawClaim) (*types.MsgWithdrawClaimResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
 


### PR DESCRIPTION
### Start the eventNonce counter at last observed

Previously the last seen event nonce for an ethereum oracle always
started at zero.

if a new validator joined the set and had never submitted
an event before they would need to play back the entire event history
in order to catch up.

From an efficiency standpoint this could involve searching over
millions of blocks and submitting thousands or tens of thousands
of oracle messages.

This patch resolves that issue starting any validator who has never
submitted an oracle event at the last observed nonce.

### More efficient and correct nonce bootstrapping

This new oracle resync function handles the corner case where an
orchestrator has crashed and needs to be restarted and during that time
has missed the first eventNonce on the Ethereum blockchain during that time.

Previously this case was ignored, if the validator had never submitted any
oracle claims before we simply assumed no events had ever happened. This
can't be ignored now becuase it may result in the slashing of an
unfortunate validator. Not to mention halt the first event from being
executed if it happens to enough validators at the same time.

The new code efficiently searches back to creation of the peggy contract
and confirms that all possible events have been submitted as oracle
messages to the Cosmos chain.