### PR TITLE
Start the eventNonce counter at last observed

### DIFF
--- a/module/x/peggy/keeper/attestation.go
+++ b/module/x/peggy/keeper/attestation.go
@@ -252,7 +252,43 @@ func (k Keeper) GetLastEventNonceByValidator(ctx sdk.Context, validator sdk.ValA
 	bytes := store.Get(types.GetLastEventNonceByValidatorKey(validator))
 
 	if len(bytes) == 0 {
-		return 0
+		// in the case that we have no existing value this is the first
+		// time a validator is submitting a claim. Since we don't want to force
+		// them to replay the entire history of all events ever we can't start
+		// at zero
+		//
+		// We could start at the LastObservedEventNonce but if we do that this
+		// validator will be slashed, because they are responsible for making a claim
+		// on any attestation that has not yet passed the slashing window.
+		//
+		// Therefore we need to return to them the lowest attestation that is still within
+		// the slashing window. Since we delete attestations after the slashing window that's
+		// just the lowest observed event in the store. If no claims have been submitted in for
+		// params.SignedClaimsWindow we may have no attestations in our nonce. At which point
+		// the last observed which is a persistant and never cleaned counter will suffice.
+		lowest_observed := k.GetLastObservedEventNonce(ctx)
+		attmap := k.GetAttestationMapping(ctx)
+		// no new claims in params.SignedClaimsWindow, we can return the current value
+		// because the validator can't be slashed for an event that has already passed.
+		// so they only have to worry about the *next* event to occur
+		if len(attmap) == 0 {
+			return lowest_observed
+		}
+		for nonce, atts := range attmap {
+			for att := range atts {
+				if atts[att].Observed && nonce < lowest_observed {
+					lowest_observed = nonce
+				}
+			}
+		}
+		// return the latest event minus one so that the validator
+		// can submit that event and avoid slashing. special case
+		// for zero
+		if lowest_observed > 0 {
+			return lowest_observed - 1
+		} else {
+			return 0
+		}
 	}
 	return types.UInt64FromBytes(bytes)
 }


### PR DESCRIPTION
Previously the last seen event nonce for an ethereum oracle always
started at zero.

if a new validator joined the set and had never submitted
an event before they would need to play back the entire event history
in order to catch up.

From an efficiency standpoint this could involve searching over
millions of blocks and submitting thousands or tens of thousands
of oracle messages.

This patch resolves that issue starting any validator who has never
submitted an oracle event at the last observed nonce. This isn't
correct as it actually needs to be the last observed event that is
not yet past the slashing window. 